### PR TITLE
svn TagOnSuccess misses TagCommitMessage and TagNameFormat configurations

### DIFF
--- a/project/UnitTests/Core/SourceControl/SvnTest.cs
+++ b/project/UnitTests/Core/SourceControl/SvnTest.cs
@@ -12,7 +12,8 @@ using ThoughtWorks.CruiseControl.Core.Util;
 
 namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol
 {
-	[TestFixture]
+
+    [TestFixture]
 	public class SvnTest : ProcessExecutorTestFixtureBase
 	{
 		private Svn svn;
@@ -67,6 +68,8 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol
 	<username>user</username>
 	<password>password</password>
 	<tagOnSuccess>true</tagOnSuccess>
+    <tagCommitMessage>MyTagMessage</tagCommitMessage>
+    <tagNameFormat>MyTagNameFormat</tagNameFormat>
 	<tagWorkingCopy>true</tagWorkingCopy>
 	<tagBaseUrl>svn://myserver/mypath/tags</tagBaseUrl>
 	<autoGetSource>true</autoGetSource>
@@ -81,6 +84,8 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol
 			Assert.AreEqual("user", svn.Username);
 			Assert.AreEqual("password", svn.Password.PrivateValue);
 			Assert.AreEqual(true, svn.TagOnSuccess);
+            Assert.AreEqual("MyTagMessage", svn.TagCommitMessage);
+            Assert.AreEqual("MyTagNameFormat", svn.TagNameFormat);
             Assert.AreEqual(true, svn.TagWorkingCopy);
 			Assert.AreEqual(true, svn.AutoGetSource);
 			Assert.AreEqual(true, svn.CheckExternals);
@@ -147,6 +152,26 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol
 			svn.LabelSourceControl(IntegrationResultMother.CreateSuccessful("foo"));
 		}
 
+        [Test]
+        public void ShouldApplyLabelWithCustomMessageIfTagOnSuccessTrueAndACustomMessageIsSpecified()
+        {
+            ExpectToExecuteArguments(string.Format(@"copy -m ""a---- foo ----a"" {0} svn://someserver/tags/foo/foo --no-auth-cache --non-interactive", StringUtil.AutoDoubleQuoteString(DefaultWorkingDirectory)));
+         
+            svn.TagOnSuccess = true;
+            svn.TagCommitMessage = "a---- {0} ----a";
+            svn.LabelSourceControl(IntegrationResultMother.CreateSuccessful("foo"));
+        }
+
+        [Test]
+        public void ShouldApplyTagNameFormatWithCustomFormatIfTagOnSuccessTrueAndATagNameFormatIsSpecified()
+        {
+            ExpectToExecuteArguments(string.Format(@"copy -m ""CCNET build bar"" {0} svn://someserver/tags/foo/Build/bar --no-auth-cache --non-interactive", StringUtil.AutoDoubleQuoteString(DefaultWorkingDirectory)));
+            
+            svn.TagOnSuccess = true;
+            svn.TagNameFormat = "Build/{0}";
+        
+            svn.LabelSourceControl(IntegrationResultMother.CreateSuccessful("bar"));
+        }
 		[Test]
 		public void ShouldApplyLabelUsingRebasedWorkingDirectory()
 		{

--- a/project/core/sourcecontrol/Svn.cs
+++ b/project/core/sourcecontrol/Svn.cs
@@ -196,6 +196,8 @@ namespace ThoughtWorks.CruiseControl.Core.Sourcecontrol
             this.AuthCaching = AuthCachingMode.None;
             this.Executable = DefaultExecutable;
             this.TagOnSuccess = false;
+            this.TagCommitMessage = "CCNET build {0}";
+            this.TagNameFormat = "{0}";
             this.TagWorkingCopy = false;
             this.DeleteObstructions = false;
             this.AutoGetSource = true;
@@ -246,6 +248,23 @@ namespace ThoughtWorks.CruiseControl.Core.Sourcecontrol
         /// <default>Project Working Directory</default>
         [ReflectorProperty("workingDirectory", Required = false)]
         public string WorkingDirectory { get; set; }
+
+        /// <summary>
+        /// Format string for the commit message of each tag. \{0\} is the placeholder for the current build label. 
+        /// </summary>
+        /// <version>1.5</version>
+        /// <default>CCNet Build \{0\}</default>
+        [ReflectorProperty("tagCommitMessage", Required = false)]
+        public string TagCommitMessage { get; set; }
+
+        /// <summary>
+        /// Format string for the name of each tag. Make sure you're only using allowed characters. \{0\} is the placeholder for the current
+        /// build label. 
+        /// </summary>
+        /// <version>1.5</version>
+        /// <default>CCNet-Build-\{0\}</default>
+        [ReflectorProperty("tagNameFormat", Required = false)]
+        public string TagNameFormat { get; set; }
 
         /// <summary>
         /// Indicates that the repository should be tagged if the build succeeds. 
@@ -813,9 +832,10 @@ namespace ThoughtWorks.CruiseControl.Core.Sourcecontrol
             return pos;
         }
 
-        private static string TagMessage(string label)
+        private string TagMessage(string label)
         {
-            return string.Format(System.Globalization.CultureInfo.CurrentCulture,"-m \"CCNET build {0}\"", label);
+            return string.Format(System.Globalization.CultureInfo.CurrentCulture,"-m \"{0}\"", string.Format(CultureInfo.CurrentCulture, TagCommitMessage, label));
+
         }
 
         private string TagSource(IIntegrationResult result)
@@ -829,7 +849,7 @@ namespace ThoughtWorks.CruiseControl.Core.Sourcecontrol
 
         private string TagDestination(string label)
         {
-            return string.Format(System.Globalization.CultureInfo.CurrentCulture,"{0}/{1}", TagBaseUrl, label);
+            return string.Format(System.Globalization.CultureInfo.CurrentCulture,"{0}/{1}", TagBaseUrl, string.Format(CultureInfo.CurrentCulture, TagNameFormat, label));
         }
 
         private void AppendCommonSwitches(PrivateArguments buffer)


### PR DESCRIPTION
I want to make it possible to specify a TagName and a specific commit Message when tagging on successful builds,

Thank you,

Signed-off-by: JorgSieber jorgsieber@eurofins.com
