### PR TITLE
webdashboard loads again in VS2010

### DIFF
--- a/project/WebDashboard/WebDashboard.csproj
+++ b/project/WebDashboard/WebDashboard.csproj
@@ -932,4 +932,6 @@ xcopy/y/q "$(SolutionDir)\xsl\*.xsl" "$(ProjectDir)\xsl"</PostBuildEvent>
       </FlavorProperties>
     </VisualStudio>
   </ProjectExtensions>
-</Project>
+   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" Condition="exists('$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets')" />
+
+  </Project>


### PR DESCRIPTION
add check on imports webproject setting in WebDashboard.csproj, so it
still loads in VS2010social.msdn.microsoft.com/Forums/en-US/tfsbuild/thread/fc5e7c6b-0ecd-4c5f-bda2-e5c7f19221a8

at the bottom of that page is the solution
