### PR TITLE
Avoid non-existant Microsoft.JScript assembly when compiling under Mono

### DIFF
--- a/ccnet.build
+++ b/ccnet.build
@@ -114,6 +114,10 @@
 			<!-- This is a hack until CCTrayLib uses plugins for Windows only stuff -->
 			<property name="DISABLE_COM" value="${platform::is-unix()}" />
 
+			<!-- Microsoft.JScript was deprecated and removed in mono in 2010 -->
+			<!-- https://github.com/mono/mono/commit/2d66a50bc6df7497e1426d693395906d31f0e490 -->
+			<property name="DISABLE_JSCRIPT" value="${framework::get-family(nant.settings.currentframework) == 'mono'}" />
+
 			<!-- Hack for current xbuild issues on Mono 2.5 -->
 			<environment>
 				<variable name="MONO_IOMAP" value="all" if="${framework::get-family(nant.settings.currentframework) == 'mono'}" />

--- a/project/core/Config/preprocessor/Evaluator.cs
+++ b/project/core/Config/preprocessor/Evaluator.cs
@@ -1,4 +1,6 @@
+
 using System;
+#if !DISABLE_JSCRIPT
 using System.CodeDom;
 using System.CodeDom.Compiler;
 using System.IO;
@@ -6,11 +8,13 @@ using System.Reflection;
 using System.Text;
 using Microsoft.JScript;
 using Convert = System.Convert;
+#endif
 
 namespace ThoughtWorks.CruiseControl.Core.Config.Preprocessor
 {
     public class Evaluator
     {
+#if !DISABLE_JSCRIPT
         // Fields
         private const string JSCRIPT_SOURCE =
             @"import System.IO;
@@ -127,5 +131,41 @@ namespace ThoughtWorks.CruiseControl.Core.Config.Preprocessor
                 throw new ApplicationException(
                     "This feature requires JSCRIPT.NET and is not supported under Mono" );
         }
+#else
+        public static bool EvalToBool(string statement)
+        {
+            throw new NotSupportedException("Not compilable under Mono");
+        }
+
+        public static double EvalToDouble(string statement)
+        {
+            throw new NotSupportedException("Not compilable under Mono");
+        }
+
+        public static int EvalToInteger(string statement)
+        {
+            throw new NotSupportedException("Not compilable under Mono");
+        }
+
+        public static object EvalToObject(string statement)
+        {
+            throw new NotSupportedException("Not compilable under Mono");
+        }
+
+        public static string EvalToString(string statement)
+        {
+            throw new NotSupportedException("Not compilable under Mono");
+        }
+
+        public static T EvalToType<T>(string expression)
+        {
+            throw new NotSupportedException("Not compilable under Mono");
+        }
+
+        public static string StringAsLiteral(string theString)
+        {
+            throw new NotSupportedException("Not compilable under Mono");
+        }
+#endif
     }
 }

--- a/project/core/core.csproj
+++ b/project/core/core.csproj
@@ -112,6 +112,9 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
+  <PropertyGroup Condition="$(DISABLE_JSCRIPT) == true">
+    <DefineConstants>DISABLE_JSCRIPT</DefineConstants>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="edtFTPnet, Version=1.3.0.0, Culture=neutral, PublicKeyToken=4b0c991f43097782">
       <SpecificVersion>False</SpecificVersion>


### PR DESCRIPTION
Slowly, we're getting somewhere. After this, ccnet compiles.
