### PR TITLE
For issue 45

### DIFF
--- a/project/core/state/FileStateManager.cs
+++ b/project/core/state/FileStateManager.cs
@@ -58,14 +58,14 @@ namespace ThoughtWorks.CruiseControl.Core.State
         [ReflectorProperty("directory", Required=false)]
         public string StateFileDirectory
 		{
-			get { return stateFileDirectory; }
-			set
-			{
-                if (!string.IsNullOrEmpty(value))
-					fileSystem.EnsureFolderExists(value);
+			get 
+            { 
+                if (!string.IsNullOrEmpty(stateFileDirectory))
+					fileSystem.EnsureFolderExists(stateFileDirectory);
 
-				stateFileDirectory = value;
-			}
+                return stateFileDirectory; 
+            }
+			set { stateFileDirectory = value; }
 		}
 
         /// <summary>


### PR DESCRIPTION
Must ensure state folder exists whenever it is read, not when it is set, so that it is also created after being streamed out of the config file. (Issue #45, http://www.cruisecontrolnet.org/issues/45)
