### PR TITLE
powershell : when script has drive specification, use it as a fixed path

### DIFF
--- a/project/core/tasks/PowerShellTask.cs
+++ b/project/core/tasks/PowerShellTask.cs
@@ -398,15 +398,25 @@ namespace ThoughtWorks.CruiseControl.Core.Tasks
 
             if (!string.IsNullOrEmpty(Script))
             {
-                if (ConfiguredScriptsDirectory.EndsWith("\\"))
+
+                if (Script.IndexOf(":") == 1) //drive letter specified, so it's not a relative path
                 {
-                    builder.AppendArgument(@"""" + ConfiguredScriptsDirectory + Script + @"""");
+                    builder.AppendArgument(@"""" + Script + @"""");
                 }
                 else
                 {
-                    builder.AppendArgument(@"""" + ConfiguredScriptsDirectory + "\\" + Script + @"""");
+
+                    if (ConfiguredScriptsDirectory.EndsWith("\\"))
+                    {
+                        builder.AppendArgument(@"""" + ConfiguredScriptsDirectory + Script + @"""");
+                    }
+                    else
+                    {
+                        builder.AppendArgument(@"""" + ConfiguredScriptsDirectory + "\\" + Script + @"""");
+                    }
                 }
             }
+
 
             if (!string.IsNullOrEmpty(BuildArgs)) builder.AppendArgument(BuildArgs);
             return builder.ToString();


### PR DESCRIPTION
when script has drive specification, use it as a fixed path
