### PR TITLE
provide a username for the nullsource control when always modified=true

### DIFF
--- a/project/core/sourcecontrol/NullSourceControl.cs
+++ b/project/core/sourcecontrol/NullSourceControl.cs
@@ -76,6 +76,7 @@ namespace ThoughtWorks.CruiseControl.Core.Sourcecontrol
                 mod.FileName = "AlwaysModified";
                 mod.FolderName = "NullSourceControl";
                 mod.ModifiedTime = DateTime.Now;
+                mod.UserName = "JohnWayne";
                 mods[0] = mod;
                 return mods;
             }

--- a/project/service/ccnet.config
+++ b/project/service/ccnet.config
@@ -13,12 +13,18 @@
                initialSeconds="5"/>
     </triggers>
 
+		<sourcecontrol type="nullSourceControl" 
+                   alwaysModified="true">
+		</sourcecontrol> 
+	
     <tasks>
-      <exec>
-        <executable>ping.exe</executable>
-        <buildArgs>localhost</buildArgs>
-        <buildTimeoutSeconds>15</buildTimeoutSeconds>
-      </exec>
+		<exec>
+			<!-- if you want the task to fail, ping an unknown server -->
+			<executable>ping.exe</executable>
+			<buildArgs>localhost2</buildArgs>
+			<buildTimeoutSeconds>15</buildTimeoutSeconds>
+			<description>Pinging a server</description>
+		</exec>
     </tasks>
 
     <publishers>
@@ -28,6 +34,5 @@
     </publishers>
 
   </project>
-
 
 </cruisecontrol>


### PR DESCRIPTION
updated the standard config with a source control section, and an updated task section
