### PR TITLE
NUnit stylesheet

### DIFF
--- a/project/UnitTests/CustomAssertion.cs
+++ b/project/UnitTests/CustomAssertion.cs
@@ -43,6 +43,15 @@ namespace ThoughtWorks.CruiseControl.UnitTests
 			Assert.IsTrue(Regex.IsMatch(actual, pattern), message);
 		}
 
+		public static void AssertMatchCount(int expectedCount, string pattern, string actual)
+		{
+			int actualCount = Regex.Matches(actual, pattern).Count;
+			string message = string.Format(System.Globalization.CultureInfo.CurrentCulture, 
+			                               "Actual string <{0}> \nmatches pattern <{1}> \n {2} times, expected was {3} times", 
+			                               actual, pattern, actualCount, expectedCount);
+			Assert.AreEqual(expectedCount, actualCount, message);
+		}
+
 		public static void AssertFalse(bool assert)
 		{
 			Assert.IsTrue(!assert);

--- a/project/UnitTests/Xsl/NUnitStylesheetTest.cs
+++ b/project/UnitTests/Xsl/NUnitStylesheetTest.cs
@@ -1,4 +1,5 @@
 using NUnit.Framework;
+using System.Xml.Linq;
 
 namespace ThoughtWorks.CruiseControl.UnitTests.Xsl
 {
@@ -14,7 +15,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Xsl
 		public void ShouldShowTestDetailsIfIncludingOutputFromNAnt()
 		{
 			string xml = @"<cruisecontrol><build><buildresults><target><task>
-                    <test-results total=""1"" failures=""0"" not-run=""0"" date=""2005-04-29"" time=""9:02 PM"">
+					<test-results total=""1"" failures=""0"" not-run=""0"" date=""2005-04-29"" time=""9:02 PM"">
 						<test-suite><results>
 							<test-case executed=""True"" />
 						</results></test-suite>
@@ -23,6 +24,34 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Xsl
 
 			string actualXml = LoadStylesheetAndTransformInput(xml);
 			CustomAssertion.AssertContains("Tests executed:</td><td>1", actualXml);
+		}
+
+		[Test]
+		public void ShouldShowEachTestSuiteOnlyOnce()
+		{
+			string xml = @"<cruisecontrol><build><buildresults><target><task>
+					<test-results total=""4"" failures=""1"" not-run=""3"" date=""2012-03-03"" time=""13:11:39"">
+						<test-suite type=""TestFixture"" name=""Failed"" executed=""True"" result=""Failure"" success=""False""><results>
+							<test-case name=""Failed.Fail"" executed=""True"" result=""Failure"" success=""False"" />
+							<test-case name=""Failed.Ignore"" executed=""False"" result=""Ignored"" />
+							<test-case name=""Failed.Pass"" executed=""True"" result=""Success"" success=""True"" />
+						</results></test-suite>
+							<test-suite type=""TestFixture"" name=""Ignored"" executed=""True"" result=""Success"" success=""True""><results>
+							<test-case name=""Ignored.Ignore"" executed=""False"" result=""Ignored"" />
+							<test-case name=""Ignored.Pass"" executed=""True"" result=""Success"" success=""True"" />
+						</results></test-suite>
+							<test-suite type=""TestFixture"" name=""IgnoredOnly"" executed=""True"" result=""Inconclusive"" success=""False""><results>
+							<test-case name=""IgnoredOnly.Ignore"" executed=""False"" result=""Ignored"" />
+						</results></test-suite>
+							<test-suite type=""TestFixture"" name=""Passed"" executed=""True"" result=""Success"" success=""True""><results>
+							<test-case name=""Passed.Pass"" executed=""True"" result=""Success"" success=""True"" />
+						</results></test-suite>
+					</test-results>
+				</task></target></buildresults></build></cruisecontrol>";
+
+			string actualXml = LoadStylesheetAndTransformInput(xml);
+
+			CustomAssertion.AssertMatchCount(4, @"<a name=""[^""]+"">", actualXml);
 		}
 	}
 }

--- a/project/xsl/tests.xsl
+++ b/project/xsl/tests.xsl
@@ -88,7 +88,7 @@
 						<xsl:attribute name="id">img<xsl:value-of select="$test.suite.id"/></xsl:attribute>
 						<xsl:attribute name="onclick">javascript:toggleDiv('img<xsl:value-of select="$test.suite.id"/>', 'divDetails<xsl:value-of select="$test.suite.id"/>');</xsl:attribute>
 					</input>&#160;<xsl:value-of select="$test.suite.name"/>
-            </td>
+				</td>
 			</tr>
 		</table>
 		<div>
@@ -100,13 +100,16 @@
 						<th>Status</th>
 						<th>Progress</th>
 					</tr>
-					<xsl:apply-templates select=".//test-suite[@success='False'][results/test-case]">
+					<xsl:apply-templates select=".//test-suite[@result='Failure'][results/test-case]">
 						<xsl:sort select="@name" order="ascending" data-type="text"/>
 					</xsl:apply-templates>
-					<xsl:apply-templates select=".//test-suite[results/test-case/@executed='False']">
+					<xsl:apply-templates select=".//test-suite[@result='Inconclusive'][results/test-case]">
 						<xsl:sort select="@name" order="ascending" data-type="text"/>
 					</xsl:apply-templates>
-					<xsl:apply-templates select=".//test-suite[@success='True'][results/test-case/@executed='True']" mode="success">
+					<xsl:apply-templates select=".//test-suite[@result='Success'][results/test-case/@executed='False']">
+						<xsl:sort select="@name" order="ascending" data-type="text"/>
+					</xsl:apply-templates>
+					<xsl:apply-templates select=".//test-suite[@result='Success'][results/test-case/@executed='True']" mode="success">
 						<xsl:sort select="@name" order="ascending" data-type="text"/>
 					</xsl:apply-templates>
 				</table>


### PR DESCRIPTION
When NUnit test results contain ignored tests the existing stylesheet listed the test suites containing them twice. I changed the stylesheet to prevent this from happening and added a test for this case.
