### PR TITLE
Fix unit tests failure: contains French char and nbsp char

### DIFF
--- a/project/UnitTests/Core/SourceControl/Telelogic/SynergyClientTest.cs
+++ b/project/UnitTests/Core/SourceControl/Telelogic/SynergyClientTest.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Globalization;
 using Exortech.NetReflector;
 using NMock;
@@ -209,7 +209,7 @@ Current project could not be identified.
 		[Test]
 		public void GetReconfigureTimeShouldHandleNonUSDates()
 		{
-			string dateString = "samedi 2 d�cembre 2006";
+            string dateString = "samedi 2 décembre 2006";
 			IMock mockCommand = new DynamicMock(typeof(ISynergyCommand));
 			mockCommand.ExpectAndReturn("Execute", ProcessResultFixture.CreateSuccessfulResult(dateString), new IsAnything());
 			SynergyConnectionInfo connectionInfo = new SynergyConnectionInfo();

--- a/project/UnitTests/Xsl/AlternativeNUnitStylesheetTest.cs
+++ b/project/UnitTests/Xsl/AlternativeNUnitStylesheetTest.cs
@@ -20,7 +20,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Xsl
 				</task></target></buildresults></build></cruisecontrol>";
 
 			string actualXml = LoadStylesheetAndTransformInput(xml);
-			CustomAssertion.AssertContains("6 tests", actualXml);
+			CustomAssertion.AssertContains("6\xA0tests", actualXml);
 		}
 	}
 }


### PR DESCRIPTION
A non-French Windows will fail the test.
Encode that file in UTF-8 BOM.
nbsp char can be represented in \xA0
