### PR TITLE
baseFolder relative to working directory for PackageFolder

### DIFF
--- a/project/core/publishers/PackageFolder.cs
+++ b/project/core/publishers/PackageFolder.cs
@@ -101,7 +101,18 @@ namespace ThoughtWorks.CruiseControl.Core.Publishers
         public IEnumerable<string> Package(IIntegrationResult result, ZipOutputStream zipStream)
         {
             var filesAdded = new List<string>();
-            var effectiveBaseFolder = (BaseFolder == null) ? result.WorkingDirectory : BaseFolder;
+
+            string effectiveBaseFolder;
+            if (BaseFolder == null)
+            {
+                effectiveBaseFolder = result.WorkingDirectory;
+            }
+            else
+            {
+                // If base is relative, make it relative to working directory and ensure we convert to absolute path
+                effectiveBaseFolder = Path.IsPathRooted(this.BaseFolder) ? this.BaseFolder : Path.GetFullPath(result.BaseFromWorkingDirectory(this.BaseFolder));
+            }
+            
             var fullName = Path.IsPathRooted(this.SourceFolder) ? this.SourceFolder : result.BaseFromWorkingDirectory(this.SourceFolder);
             var folderInfo = new DirectoryInfo(fullName);
             if (folderInfo.Exists)


### PR DESCRIPTION
My first patch ever so hopefully I did this the right way.
This is related to the recent fix you merged (Issue93).

This is a small enhancement that allows one to create the baseFolder relative to the working directory. This allows one to specify an arbitrary source folder (note it could relative to wokingDirectory) and ensure the path is excluded from the ZIP file. Before this patch, the only way to do it is to provide the absolute path in the baseFolder property, which is clunky.
