### PR TITLE
tooltip provider for messages may only handle real messages, not build related ones

### DIFF
--- a/project/CCTrayLib/Presentation/TrayIconFacade.cs
+++ b/project/CCTrayLib/Presentation/TrayIconFacade.cs
@@ -54,6 +54,9 @@ namespace ThoughtWorks.CruiseControl.CCTrayLib.Presentation
 
         private void Monitor_MessageReceived(string projectName, ThoughtWorks.CruiseControl.Remote.Message message)
 		{
+            // filter out unwanted messages, this should only allow messages that are not 'build' related
+            // example of messages to allow : fixing the build, aborted the build, ...
+            if (message.Kind == Remote.Message.MessageKind.NotDefined) return;
             trayIcon.ShowBalloonTip(5000, projectName, message.ToString(), ToolTipIcon.Info);
 		}
 


### PR DESCRIPTION
fixes (Bug #104) : The CCTray app balloon shows always report builds even if it is set only to show warnings or errors.
