### PR TITLE
added the CCNetBuildTime2 integration property in HH_mm_ss format to support its use as a folder or file name in the windows file system (http://cruisecontrolnet.org/issues/116)

### DIFF
--- a/doc/CCNET/Dynamic Parameters.html
+++ b/doc/CCNET/Dynamic Parameters.html
@@ -84,9 +84,9 @@
 <td class='confluenceTd'>&nbsp;</td>
 </tr>
 <tr>
-<td class='confluenceTd'> CCNetBuildTime2 </td>
-<td class='confluenceTd'> The time of the start of the build (in HH_mm_ss format) </td>
-<td class='confluenceTd'> 08_45_12 </td>
+<td class='confluenceTd'> CCNetBuildGuid </td>
+<td class='confluenceTd'> A unique GUID for the build (in 0123456789abcdef0123456789abcdef format) </td>
+<td class='confluenceTd'> 0123456789abcdef0123456789abcdef </td>
 <td class='confluenceTd'>&nbsp;</td>
 </tr>
 <tr>

--- a/doc/CCNET/Executable Task.html
+++ b/doc/CCNET/Executable Task.html
@@ -216,9 +216,9 @@ In Windows use cmd.exe as the executable, and pass the wanted command as an argu
 <td class='confluenceTd'>&nbsp;</td>
 </tr>
 <tr>
-<td class='confluenceTd'> CCNetBuildTime2 </td>
-<td class='confluenceTd'> The time of the start of the build (in HH_mm_ss format) </td>
-<td class='confluenceTd'> 08_45_12 </td>
+<td class='confluenceTd'> CCNetBuildGuid </td>
+<td class='confluenceTd'> A unique GUID for the build (in 0123456789abcdef0123456789abcdef format) </td>
+<td class='confluenceTd'> 0123456789abcdef0123456789abcdef </td>
 <td class='confluenceTd'>&nbsp;</td>
 </tr>
 <tr>

--- a/doc/CCNET/Ftp task - Publisher.html
+++ b/doc/CCNET/Ftp task - Publisher.html
@@ -212,9 +212,9 @@
 <td class='confluenceTd'>&nbsp;</td>
 </tr>
 <tr>
-<td class='confluenceTd'> CCNetBuildTime2 </td>
-<td class='confluenceTd'> The time of the start of the build (in HH_mm_ss format) </td>
-<td class='confluenceTd'> 08_45_12 </td>
+<td class='confluenceTd'> CCNetBuildGuid </td>
+<td class='confluenceTd'> A unique GUID for the build (in 0123456789abcdef0123456789abcdef format) </td>
+<td class='confluenceTd'> 0123456789abcdef0123456789abcdef </td>
 <td class='confluenceTd'>&nbsp;</td>
 </tr>
 <tr>

--- a/doc/CCNET/Integration Properties.html
+++ b/doc/CCNET/Integration Properties.html
@@ -69,9 +69,9 @@
 <td class='confluenceTd'>&nbsp;</td>
 </tr>
 <tr>
-<td class='confluenceTd'> CCNetBuildTime2 </td>
-<td class='confluenceTd'> The time of the start of the build (in HH_mm_ss format) </td>
-<td class='confluenceTd'> 08_45_12 </td>
+<td class='confluenceTd'> CCNetBuildGuid </td>
+<td class='confluenceTd'> A unique GUID for the build (in 0123456789abcdef0123456789abcdef format) </td>
+<td class='confluenceTd'> 0123456789abcdef0123456789abcdef </td>
 <td class='confluenceTd'>&nbsp;</td>
 </tr>
 <tr>

--- a/doc/CCNET/MsBuild Task.html
+++ b/doc/CCNET/MsBuild Task.html
@@ -214,9 +214,9 @@ In order to work with the results of MsBuild it is important to use a custom xml
 <td class='confluenceTd'>&nbsp;</td>
 </tr>
 <tr>
-<td class='confluenceTd'> CCNetBuildTime2 </td>
-<td class='confluenceTd'> The time of the start of the build (in HH_mm_ss format) </td>
-<td class='confluenceTd'> 08_45_12 </td>
+<td class='confluenceTd'> CCNetBuildGuid </td>
+<td class='confluenceTd'> A unique GUID for the build (in 0123456789abcdef0123456789abcdef format) </td>
+<td class='confluenceTd'> 0123456789abcdef0123456789abcdef </td>
 <td class='confluenceTd'>&nbsp;</td>
 </tr>
 <tr>

--- a/doc/CCNET/NAnt Task.html
+++ b/doc/CCNET/NAnt Task.html
@@ -240,9 +240,9 @@
 <td class='confluenceTd'>&nbsp;</td>
 </tr>
 <tr>
-<td class='confluenceTd'> CCNetBuildTime2 </td>
-<td class='confluenceTd'> The time of the start of the build (in HH_mm_ss format) </td>
-<td class='confluenceTd'> 08_45_12 </td>
+<td class='confluenceTd'> CCNetBuildGuid </td>
+<td class='confluenceTd'> A unique GUID for the build (in 0123456789abcdef0123456789abcdef format) </td>
+<td class='confluenceTd'> 0123456789abcdef0123456789abcdef </td>
 <td class='confluenceTd'>&nbsp;</td>
 </tr>
 <tr>

--- a/doc/CCNET/Visual Studio Task.html
+++ b/doc/CCNET/Visual Studio Task.html
@@ -237,9 +237,9 @@
 <td class='confluenceTd'>&nbsp;</td>
 </tr>
 <tr>
-<td class='confluenceTd'> CCNetBuildTime2 </td>
-<td class='confluenceTd'> The time of the start of the build (in HH_mm_ss format) </td>
-<td class='confluenceTd'> 08_45_12 </td>
+<td class='confluenceTd'> CCNetBuildGuid </td>
+<td class='confluenceTd'> A unique GUID for the build (in 0123456789abcdef0123456789abcdef format) </td>
+<td class='confluenceTd'> 0123456789abcdef0123456789abcdef </td>
 <td class='confluenceTd'>&nbsp;</td>
 </tr>
 <tr>

--- a/project/UnitTests/Core/IntegrationResultTest.cs
+++ b/project/UnitTests/Core/IntegrationResultTest.cs
@@ -208,8 +208,8 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core
 			Assert.AreEqual(workingDir, result.IntegrationProperties[IntegrationPropertyNames.CCNetWorkingDirectory]);
 			// We purposefully use culture-independent string formats
             Assert.AreEqual("2005-06-06", result.IntegrationProperties[IntegrationPropertyNames.CCNetBuildDate]);
+            Assert.IsTrue(IsGuid(result.IntegrationProperties[IntegrationPropertyNames.CCNetBuildGuid].ToString()));
             Assert.AreEqual("08:45:00", result.IntegrationProperties[IntegrationPropertyNames.CCNetBuildTime]);
-            Assert.AreEqual("08_45_00", result.IntegrationProperties[IntegrationPropertyNames.CCNetBuildTime2]);
             Assert.AreEqual(BuildCondition.IfModificationExists, result.IntegrationProperties[IntegrationPropertyNames.CCNetBuildCondition]);
             Assert.AreEqual(IntegrationStatus.Unknown, result.IntegrationProperties[IntegrationPropertyNames.CCNetIntegrationStatus]);
             Assert.AreEqual(IntegrationStatus.Unknown, result.IntegrationProperties[IntegrationPropertyNames.CCNetLastIntegrationStatus]);
@@ -229,6 +229,20 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core
             Assert.AreEqual(1, Modifiers.Count);
             Assert.AreEqual("John", Modifiers[0]);
 		}
+
+        private bool IsGuid(string guidString)
+        {
+            try
+            {
+                Guid guid = new Guid(guidString);
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
 
 		[Test]
 		public void VerifyIntegrationArtifactDir()

--- a/project/UnitTests/Core/ProcessExecutorTestFixtureBase.cs
+++ b/project/UnitTests/Core/ProcessExecutorTestFixtureBase.cs
@@ -18,7 +18,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core
         protected DateTime testDate = new DateTime(2005, 06, 06, 08, 45, 00);
         protected string testDateString = "2005-06-06";
         protected string testTimeString = "08:45:00";
-        protected string testTimeString2 = "08_45_00";
+        protected string testGuid = "0123456789abcdef0123456789abcdef";
 
         protected IMock mockProcessExecutor;
         protected string defaultExecutable;

--- a/project/UnitTests/Core/Tasks/MsBuildTaskTest.cs
+++ b/project/UnitTests/Core/Tasks/MsBuildTaskTest.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
@@ -39,6 +40,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Tasks
             result = IntegrationResult();
             result.Label = "1.0";
             result.ArtifactDirectory = DefaultWorkingDirectory;
+            result.Guid = new Guid("0123456789abcdef0123456789abcdef");
             logfile = Path.Combine(result.ArtifactDirectory, MsBuildTask.LogFilename);
             TempFileUtil.DeleteTempFile(logfile);
         }
@@ -96,11 +98,12 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Tasks
             // are not sorted alphabetically.
             string expectedProperties = string.Join(";", new string[]
             {
+                //in alphabetical order
                 string.Format("/p:CCNetArtifactDirectory={0}", StringUtil.AutoDoubleQuoteString(result.ArtifactDirectory)), 
                 "CCNetBuildCondition=IfModificationExists",
                 string.Format("CCNetBuildDate={0}", testDateString),
+                string.Format("CCNetBuildGuid={0}", testGuid),
                 string.Format("CCNetBuildTime={0}", testTimeString), 
-                string.Format("CCNetBuildTime2={0}", testTimeString2), 
                 "CCNetFailureTasks=", 
                 "CCNetFailureUsers=", 
                 "CCNetIntegrationStatus=Success",
@@ -245,11 +248,12 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Tasks
             // are not sorted alphabetically.
             return string.Join(";", new string[]
             {
+                //in alphabetical order
                 string.Format("/p:CCNetArtifactDirectory={0}", StringUtil.AutoDoubleQuoteString(result.ArtifactDirectory)), 
                 "CCNetBuildCondition=IfModificationExists",
                 string.Format("CCNetBuildDate={0}", testDateString),
+                string.Format("CCNetBuildGuid={0}", testGuid),
                 string.Format("CCNetBuildTime={0}", testTimeString), 
-                string.Format("CCNetBuildTime2={0}", testTimeString2), 
                 "CCNetFailureTasks=", 
                 "CCNetFailureUsers=", 
                 "CCNetIntegrationStatus=Success",

--- a/project/UnitTests/Core/Tasks/NAntTaskTest.cs
+++ b/project/UnitTests/Core/Tasks/NAntTaskTest.cs
@@ -23,6 +23,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Tasks
             builder = new NAntTask((ProcessExecutor) mockProcessExecutor.MockInstance);
             result = IntegrationResult();
             result.Label = "1.0";
+            result.Guid = new Guid("0123456789abcdef0123456789abcdef");
         }
 
         [TearDown]
@@ -260,11 +261,12 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Tasks
             // are not sorted alphabetically.
             return string.Join(" ", new string[]
             {
+                //in alphabetical order
                 string.Format("-D:CCNetArtifactDirectory={0}", StringUtil.AutoDoubleQuoteString(artifactDirectory)), 
                 "-D:CCNetBuildCondition=IfModificationExists",
                 string.Format("-D:CCNetBuildDate={0}", testDateString),
+                string.Format("-D:CCNetBuildGuid={0}", testGuid), 
                 string.Format("-D:CCNetBuildTime={0}", testTimeString), 
-                string.Format("-D:CCNetBuildTime2={0}", testTimeString2), 
                 "-D:CCNetFailureTasks=", 
                 "-D:CCNetFailureUsers=", 
                 "-D:CCNetIntegrationStatus=Success",

--- a/project/UnitTests/resources/UnitTestResults2.xml
+++ b/project/UnitTests/resources/UnitTestResults2.xml
@@ -8,10 +8,10 @@
                value="ForceBuild" />
     <parameter name="$CCNetBuildDate"
                value="2011-09-01" />
+    <parameter name="$CCNetBuildGuid"
+               value="0123456789abcdef0123456789abcdef" />
     <parameter name="$CCNetBuildTime"
                value="21:00:00" />
-    <parameter name="$CCNetBuildTime2"
-               value="21_00_00" />
     <parameter name="$CCNetFailureUsers"
                value="System.Collections.ArrayList" />
     <parameter name="$CCNetFailureTasks"
@@ -47,8 +47,8 @@
     <CCNetArtifactDirectory>D:\Integration\ProjectXAnalyze\Artifacts</CCNetArtifactDirectory>
     <CCNetBuildCondition>ForceBuild</CCNetBuildCondition>
     <CCNetBuildDate>2011-09-01</CCNetBuildDate>
+    <CCNetBuildGuid>0123456789abcdef0123456789abcdef</CCNetBuildGuid>
     <CCNetBuildTime>21:00:00</CCNetBuildTime>
-    <CCNetBuildTime2>21_00_00</CCNetBuildTime2>
     <CCNetFailureUsers />
     <CCNetFailureTasks />
     <CCNetIntegrationStatus>Success</CCNetIntegrationStatus>

--- a/project/core/IIntegrationResult.cs
+++ b/project/core/IIntegrationResult.cs
@@ -76,6 +76,12 @@ namespace ThoughtWorks.CruiseControl.Core
         /// <remarks></remarks>
 		string Label { get; set; }
         /// <summary>
+        /// Gets or sets the build Guid.	
+        /// </summary>
+        /// <value>The build Guid.</value>
+        /// <remarks></remarks>
+        Guid Guid { get; set; }
+        /// <summary>
         /// Gets or sets the status.	
         /// </summary>
         /// <value>The status.</value>

--- a/project/core/IntegrationPropertyNames.cs
+++ b/project/core/IntegrationPropertyNames.cs
@@ -51,9 +51,9 @@ namespace ThoughtWorks.CruiseControl.Core
         /// </summary>
         public const string CCNetBuildTime = "CCNetBuildTime";
         /// <summary>
-        /// The time of the start of the build (in HH_mm_ss format) 
+        /// A unique GUID for the build (in 0123456789abcdef0123456789abcdef format)
         /// </summary>
-        public const string CCNetBuildTime2 = "CCNetBuildTime2";
+        public const string CCNetBuildGuid = "CCNetBuildGuid";
         /// <summary>
         /// The status of the previous integration. Could be Success, Failure, Exception or Unknown 
         /// </summary>

--- a/project/core/IntegrationResult.cs
+++ b/project/core/IntegrationResult.cs
@@ -42,6 +42,7 @@ namespace ThoughtWorks.CruiseControl.Core
         private ArrayList failureUsers = new ArrayList();
         private ArrayList failureTasks = new ArrayList();
         private string label = InitialLabel;
+        private Guid guid = Guid.NewGuid();
         private DateTime startTime;
         private DateTime endTime;
         private Modification[] modifications = new Modification[0];
@@ -591,7 +592,7 @@ namespace ThoughtWorks.CruiseControl.Core
                 fullProps[IntegrationPropertyNames.CCNetNumericLabel] = NumericLabel;
                 fullProps[IntegrationPropertyNames.CCNetBuildDate] = StartTime.ToString("yyyy-MM-dd", null);
                 fullProps[IntegrationPropertyNames.CCNetBuildTime] = StartTime.ToString("HH:mm:ss", null);
-                fullProps[IntegrationPropertyNames.CCNetBuildTime2] = StartTime.ToString("HH_mm_ss", null);
+                fullProps[IntegrationPropertyNames.CCNetBuildGuid] = Guid.ToString("N"); //32 hexadecimal characters, no dashes or braces
                 fullProps[IntegrationPropertyNames.CCNetLastIntegrationStatus] = LastIntegrationStatus;
                 fullProps[IntegrationPropertyNames.CCNetListenerFile] = BuildProgressInformation.ListenerFile;
                 fullProps[IntegrationPropertyNames.CCNetFailureUsers] = FailureUsers;
@@ -601,6 +602,17 @@ namespace ThoughtWorks.CruiseControl.Core
                 if (IntegrationRequest != null) fullProps[IntegrationPropertyNames.CCNetRequestSource] = IntegrationRequest.Source;
                 return fullProps;
             }
+        }
+
+        /// <summary>
+        /// Gets or sets the build Guid.	
+        /// </summary>
+        /// <value>The build Guid.</value>
+        /// <remarks></remarks>
+        public Guid Guid
+        {
+            get { return guid; }
+            set { guid = value; }
         }
 
         /// <summary>

--- a/project/core/publishers/XmlIntegrationResultWriter.cs
+++ b/project/core/publishers/XmlIntegrationResultWriter.cs
@@ -152,16 +152,17 @@ namespace ThoughtWorks.CruiseControl.Core.Publishers
 
             writer.WriteStartElement(Elements.IntegrationProps);
             
+            //in alphabetical order
             WriteIntegrationProperty(result.IntegrationProperties[IntegrationPropertyNames.CCNetArtifactDirectory],
                                                             IntegrationPropertyNames.CCNetArtifactDirectory);
             WriteIntegrationProperty(result.IntegrationProperties[IntegrationPropertyNames.CCNetBuildCondition],
                                                             IntegrationPropertyNames.CCNetBuildCondition);
             WriteIntegrationProperty(result.IntegrationProperties[IntegrationPropertyNames.CCNetBuildDate],
                                                             IntegrationPropertyNames.CCNetBuildDate);
+            WriteIntegrationProperty(result.IntegrationProperties[IntegrationPropertyNames.CCNetBuildGuid],
+                                                            IntegrationPropertyNames.CCNetBuildGuid);
             WriteIntegrationProperty(result.IntegrationProperties[IntegrationPropertyNames.CCNetBuildTime],
                                                             IntegrationPropertyNames.CCNetBuildTime);
-            WriteIntegrationProperty(result.IntegrationProperties[IntegrationPropertyNames.CCNetBuildTime2],
-                                                            IntegrationPropertyNames.CCNetBuildTime2);
             WriteIntegrationProperty(result.IntegrationProperties[IntegrationPropertyNames.CCNetFailureUsers],
                                                             IntegrationPropertyNames.CCNetFailureUsers);
             WriteIntegrationProperty(result.IntegrationProperties[IntegrationPropertyNames.CCNetFailureTasks],


### PR DESCRIPTION
added the CCNetBuildTime2 integration property in HH_mm_ss format to support its use as a folder or file name in the windows file system (http://cruisecontrolnet.org/issues/116)
