### PR TITLE
cctray throws NullReferenceException when a non-running project is aborted (Bug #98)

### DIFF
--- a/project/CCTrayLib/Presentation/DetailStringProvider.cs
+++ b/project/CCTrayLib/Presentation/DetailStringProvider.cs
@@ -88,7 +88,10 @@ namespace ThoughtWorks.CruiseControl.CCTrayLib.Presentation
                 }
             }
 
-            if (projectStatus.CurrentMessage.Length > 0) message += " - " + projectStatus.CurrentMessage;
+            if (!string.IsNullOrEmpty(projectStatus.CurrentMessage))
+            {
+                message += " - " + projectStatus.CurrentMessage;
+            }
 
 			return message;
 		}


### PR DESCRIPTION
cctray throws NullReferenceException when a non-running project is aborted (Bug #98)
