### PR TITLE
When more than one LDAP converter is used for multiple domains say it fi...

### DIFF
--- a/project/core/publishers/EmailMessage.cs
+++ b/project/core/publishers/EmailMessage.cs
@@ -272,7 +272,11 @@ namespace ThoughtWorks.CruiseControl.Core.Publishers
                 string email = username;
                 foreach (IEmailConverter converter in emailPublisher.Converters)
                 {
-                    email = converter.Convert(email);
+                    email = converter.Convert(username);
+                    if(email != null)
+                    {
+                        break;
+                    }
                 }
 
                 if (email != null)


### PR DESCRIPTION
...nds the user on the first one it then sets it to null when it doesnt find it on the second, then a null input to the 3rd converter crashes the app.
