### PR TITLE
partially fixed http://www.cruisecontrolnet.org/issues/99

### DIFF
--- a/project/core/Project.cs
+++ b/project/core/Project.cs
@@ -952,11 +952,11 @@ namespace ThoughtWorks.CruiseControl.Core
             var mergeFailed = false;
             foreach (ITask publisher in publishers)
             {
-                var isMergeTask = publisher is IMergeTask;
+                bool isMergeTask = publisher is IMergeTask;
                 try
                 {
                     merged |= isMergeTask;
-                    var dummy = publisher as IParamatisedItem;
+                    IParamatisedItem dummy = publisher as IParamatisedItem;
                     if (dummy != null)
                     {
                         dummy.ApplyParameters(parameterValues, parameters);
@@ -1058,7 +1058,7 @@ namespace ThoughtWorks.CruiseControl.Core
             {
                 // Run the actual task
                 // publishers do not get the overall status, as they are also ran for failed builds
-                // a pulisher must have the failed status if itself failed, not if a build failed
+                // a publisher must have the failed status if itself failed, not if a build failed
                 task.Run(result);
                 if (status != null && !isPublisher)
                 {

--- a/project/core/tasks/MergeFileInfo.cs
+++ b/project/core/tasks/MergeFileInfo.cs
@@ -19,7 +19,7 @@
     /// &lt;/file&gt;
     /// </code>
     /// </example>
-    [ReflectorType("fileToMerge")]
+    [ReflectorType("file")]
     public class MergeFileInfo
     {
         #region Public properties

--- a/project/core/tasks/MergeFileSerialiser.cs
+++ b/project/core/tasks/MergeFileSerialiser.cs
@@ -51,16 +51,16 @@ namespace ThoughtWorks.CruiseControl.Core.Tasks
         				if (fileElement.Name == "file")
         				{
         					// Make sure there are no child elements
-        					var fileSubNodes = fileElement.SelectNodes("*");
+        					XmlNodeList fileSubNodes = fileElement.SelectNodes("*");
 							if (fileSubNodes != null && fileSubNodes.Count > 0)
 								throw new NetReflectorException(string.Concat("file cannot contain any sub-items.", Environment.NewLine, "XML: ", fileElement.OuterXml));
 
         					// Load the filename
-        					var newFile = new MergeFileInfo();
+                            MergeFileInfo newFile = new MergeFileInfo();
         					newFile.FileName = fileElement.InnerText;
 
         					// Load the merge action
-        					var typeAttribute = fileElement.GetAttribute("action");
+        					string typeAttribute = fileElement.GetAttribute("action");
         					if (string.IsNullOrEmpty(typeAttribute))
         					{
         						newFile.MergeAction = MergeFileInfo.MergeActionType.Merge;

--- a/project/core/tasks/MergeFilesTask.cs
+++ b/project/core/tasks/MergeFilesTask.cs
@@ -183,7 +183,7 @@ namespace ThoughtWorks.CruiseControl.Core.Tasks
                 targetFolder = Path.Combine(result.ArtifactDirectory, result.Label);
             }
 
-			foreach (var mergeFile in MergeFiles)
+			foreach (MergeFileInfo mergeFile in MergeFiles)
 			{
                 // Get the name of the file
 				string fullMergeFile = mergeFile.FileName;
@@ -194,7 +194,7 @@ namespace ThoughtWorks.CruiseControl.Core.Tasks
 
                 // Merge each file
 				WildCardPath path = new WildCardPath(fullMergeFile);
-                foreach (var fileInfo in path.GetFiles())
+                foreach (FileInfo fileInfo in path.GetFiles())
                 {
                     if (actualFileSystem.FileExists(fileInfo.FullName))
                     {


### PR DESCRIPTION
Fixed Publisher threw exception: System.InvalidCastException: Invalid cast from 'System.String' to 'ThoughtWorks.CruiseControl.Core.Tasks.MergeFileInfo'.
at System.Convert.DefaultToType(IConvertible value, Type targetType, IFormatProvider provider)
at System.Convert.ChangeType(Object value, Type conversionType, IFormatProvider provider)
at ThoughtWorks.CruiseControl.Core.Tasks.DynamicValueUtility.PropertyValue.ChangePropertyValue(Object value)
at ThoughtWorks.CruiseControl.Core.Tasks.TaskBase.ApplyParameters(Dictionary`2 parameters, IEnumerable`1 parameterDefinitions)
at ThoughtWorks.CruiseControl.Core.Project.PublishResults(IIntegrationResult result, Dictionary`2 parameterValues)
