### PR TITLE
reworked pull request 145 : Package Publisher / PackageFolder doesn't respect hierarchy when targetFolder is specified

### DIFF
--- a/project/UnitTests/IntegrationTests/PublisherTests.cs
+++ b/project/UnitTests/IntegrationTests/PublisherTests.cs
@@ -27,6 +27,8 @@ namespace ThoughtWorks.CruiseControl.UnitTests.IntegrationTests
 
             IntegrationCompleted = new System.Collections.Generic.Dictionary<string, bool>();
 
+            
+
             string workingDirectory = "Packaging01";
             string InfoFolder = "Info";
             string subInfoFolder = "Sub1";
@@ -36,7 +38,8 @@ namespace ThoughtWorks.CruiseControl.UnitTests.IntegrationTests
             string f2 = string.Format("{0}{1}b.txt",FolderContainingFiles,System.IO.Path.DirectorySeparatorChar);
             string f3 = string.Format("{0}{1}c.rtf", FolderContainingFiles, System.IO.Path.DirectorySeparatorChar);
 
-
+            var ios = new CCNet.Core.Util.IoService();
+            ios.DeleteIncludingReadOnlyObjects(FolderContainingFiles);
 
             System.IO.Directory.CreateDirectory(FolderContainingFiles);
             System.IO.File.WriteAllText(f1, "somedata");
@@ -137,6 +140,8 @@ namespace ThoughtWorks.CruiseControl.UnitTests.IntegrationTests
             string f3 = string.Format("{0}{1}c.rtf", FolderContainingFiles, System.IO.Path.DirectorySeparatorChar);
 
 
+            var ios = new CCNet.Core.Util.IoService();
+            ios.DeleteIncludingReadOnlyObjects(FolderContainingFiles);
 
             System.IO.Directory.CreateDirectory(FolderContainingFiles);
             System.IO.File.WriteAllText(f1, "somedata");
@@ -213,6 +218,113 @@ namespace ThoughtWorks.CruiseControl.UnitTests.IntegrationTests
 
             Assert.AreEqual(@"Info/Sub1/a.txtInfo/Sub1/b.txt", expectedFiles);
 
+        }
+
+        /// <summary>
+        /// test for issue 39 : Package Publisher / PackageFolder doesn't respect hierarchy when targetFolder is specified 
+        /// http://www.cruisecontrolnet.org/issues/39
+        /// </summary>
+        [Test]
+        public void PackagePublisherPackageFolderMustRespectHierarchy()
+        {
+            const string ProjectName1 = "PackageTest03";
+
+            string IntegrationFolder = System.IO.Path.Combine("scenarioTests", ProjectName1);
+            string CCNetConfigFile = System.IO.Path.Combine("IntegrationScenarios", "PackagePublisherTest03.xml");
+            string ProjectStateFile = new System.IO.FileInfo(ProjectName1 + ".state").FullName;
+
+            IntegrationCompleted = new System.Collections.Generic.Dictionary<string, bool>();
+
+            string workingDirectory = "Packaging03";
+
+            string infoFolder = string.Format("{0}{1}some{1}directories{1}deeper{1}_PublishedWebsites{1}MyProject{1}", workingDirectory, System.IO.Path.DirectorySeparatorChar);
+            string subInfoFolder = string.Format("{0}{1}AFolder{1}", infoFolder, System.IO.Path.DirectorySeparatorChar);
+            string f1 = string.Format("{0}{1}a.txt", infoFolder, System.IO.Path.DirectorySeparatorChar);
+            string f2 = string.Format("{0}{1}b.txt", subInfoFolder, System.IO.Path.DirectorySeparatorChar);
+
+
+            var ios = new CCNet.Core.Util.IoService();
+            ios.DeleteIncludingReadOnlyObjects(infoFolder);
+            ios.DeleteIncludingReadOnlyObjects("TheMegaWebSite");
+
+
+            System.IO.Directory.CreateDirectory(infoFolder);
+            System.IO.Directory.CreateDirectory(subInfoFolder);
+
+
+            System.IO.File.WriteAllText(f1, "somedata");
+            System.IO.File.WriteAllText(f2, "somedata");
+
+            IntegrationCompleted.Add(ProjectName1, false);
+
+            Log("Clear existing state file, to simulate first run : " + ProjectStateFile);
+            System.IO.File.Delete(ProjectStateFile);
+
+            Log("Clear integration folder to simulate first run");
+            if (System.IO.Directory.Exists(IntegrationFolder)) System.IO.Directory.Delete(IntegrationFolder, true);
+
+
+            CCNet.Remote.Messages.ProjectStatusResponse psr;
+            CCNet.Remote.Messages.ProjectRequest pr1 = new CCNet.Remote.Messages.ProjectRequest(null, ProjectName1);
+
+
+            Log("Making CruiseServerFactory");
+            CCNet.Core.CruiseServerFactory csf = new CCNet.Core.CruiseServerFactory();
+
+            Log("Making cruiseServer with config from :" + CCNetConfigFile);
+            using (var cruiseServer = csf.Create(true, CCNetConfigFile))
+            {
+
+                // subscribe to integration complete to be able to wait for completion of a build
+                cruiseServer.IntegrationCompleted += new EventHandler<ThoughtWorks.CruiseControl.Remote.Events.IntegrationCompletedEventArgs>(CruiseServerIntegrationCompleted);
+
+                Log("Starting cruiseServer");
+                cruiseServer.Start();
+
+                System.Threading.Thread.Sleep(250); // give time to start
+
+                Log("Forcing build");
+                CheckResponse(cruiseServer.ForceBuild(pr1));
+
+                System.Threading.Thread.Sleep(250); // give time to start the build
+
+                Log("Waiting for integration to complete");
+                while (!IntegrationCompleted[ProjectName1])
+                {
+                    for (int i = 1; i <= 4; i++) System.Threading.Thread.Sleep(250);
+                    Log(" waiting ...");
+                }
+
+                // un-subscribe to integration complete 
+                cruiseServer.IntegrationCompleted -= new EventHandler<ThoughtWorks.CruiseControl.Remote.Events.IntegrationCompletedEventArgs>(CruiseServerIntegrationCompleted);
+
+                Log("getting project status");
+                psr = cruiseServer.GetProjectStatus(pr1);
+                CheckResponse(psr);
+
+                Log("Stopping cruiseServer");
+                cruiseServer.Stop();
+
+                Log("waiting for cruiseServer to stop");
+                cruiseServer.WaitForExit(pr1);
+                Log("cruiseServer stopped");
+
+            }
+
+            Log("Checking the data");
+            string ExpectedZipFile = string.Format("{0}{1}Artifacts{1}1{1}Project-package.zip", ProjectName1, System.IO.Path.DirectorySeparatorChar);
+            Assert.IsTrue(System.IO.File.Exists(ExpectedZipFile), "zip package not found at expected location");
+
+            ICSharpCode.SharpZipLib.Zip.ZipFile zf = new ICSharpCode.SharpZipLib.Zip.ZipFile(ExpectedZipFile);
+            string expectedFiles = string.Empty;
+
+            foreach (ICSharpCode.SharpZipLib.Zip.ZipEntry ze in zf)
+            {
+                System.Diagnostics.Debug.WriteLine(ze.Name);
+                expectedFiles += ze.Name;
+            }
+
+            Assert.AreEqual(@"MegaWebSite/AFolder/b.txtMegaWebSite/a.txt", expectedFiles);
         }
 
 

--- a/project/UnitTests/UnitTests.csproj
+++ b/project/UnitTests/UnitTests.csproj
@@ -1380,7 +1380,9 @@
     <Content Include="resources\IntegrationScenarios\MultiLineInclude.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <Content Include="resources\IntegrationScenarios\PackagePublisherTest01.xml" />
     <Content Include="resources\IntegrationScenarios\PackagePublisherTest02.xml" />
+    <Content Include="resources\IntegrationScenarios\PackagePublisherTest03.xml" />
     <Content Include="resources\IntegrationScenarios\PowerShellConfig1.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>

--- a/project/UnitTests/resources/IntegrationScenarios/PackagePublisherTest03.xml
+++ b/project/UnitTests/resources/IntegrationScenarios/PackagePublisherTest03.xml
@@ -1,0 +1,28 @@
+﻿<cruisecontrol xmlns:cb="urn:ccnet.config.builder">
+
+
+  <project name="PackageTest03"
+           workingDirectory="Packaging03">
+    <triggers />
+
+    <tasks>
+      <package always="true" >
+        <name>Project-package.zip</name>
+        <packageList>
+          <packageFolder includeSubFolders="true" >
+            <sourceFolder>some\directories\deeper\_PublishedWebsites\MyProject</sourceFolder>
+            <flatten>false</flatten>
+            <targetFolder>MegaWebSite</targetFolder> 
+            <fileFilter>*.*</fileFilter>
+          </packageFolder>
+        </packageList>
+      </package>
+    </tasks>
+
+    <publishers>
+      <xmllogger />
+    </publishers>
+  </project>
+
+
+</cruisecontrol>

--- a/project/core/publishers/PackagePublisher.cs
+++ b/project/core/publishers/PackagePublisher.cs
@@ -355,7 +355,8 @@ namespace ThoughtWorks.CruiseControl.Core.Publishers
         /// <param name="tempFile"></param>
         /// <returns></returns>
         /// <remarks>
-        /// This method will also generate the correct name of the file.
+        /// This method will also generate the correct name of the file and ensure
+        /// the output directory exists.
         /// </remarks>
         private string MoveFile(IIntegrationResult result, string tempFile)
         {
@@ -376,18 +377,26 @@ namespace ThoughtWorks.CruiseControl.Core.Publishers
 
             if (!string.IsNullOrEmpty(OutputDirectory))
             {
-                // Copy the file to the output directory (so it can be used by other tasks)
                 var basePath = OutputDirectory;
                 if (!Path.IsPathRooted(basePath))
                 {
                     basePath = Path.Combine(result.ArtifactDirectory, basePath);
                 }
 
+                // Create output directory if it doesn't exist
+                if (!Directory.Exists(basePath))
+                {
+                    Log.Info(string.Format(
+                        CultureInfo.CurrentCulture, "Creating output directory '{0}'", basePath));
+                    Directory.CreateDirectory(basePath);
+                }
+
+                // Copy the file to the output directory (so it can be used by other tasks)
                 Log.Info(string.Format(
-                    CultureInfo.CurrentCulture,"Copying file to '{0}'", basePath));
+                    CultureInfo.CurrentCulture, "Copying file to '{0}'", basePath));
                 File.Copy(
-                    actualFile, 
-                    EnsureFileExtension(Path.Combine(basePath, PackageName), ".zip"), 
+                    actualFile,
+                    EnsureFileExtension(Path.Combine(basePath, PackageName), ".zip"),
                     true);
             }
 


### PR DESCRIPTION
...older is specified

patch from saadware : https://github.com/ccnet/CruiseControl.NET/pull/145
