### PR TITLE
Fix robocopy documentation

### DIFF
--- a/project/core/sourcecontrol/RobocopySourceControl.cs
+++ b/project/core/sourcecontrol/RobocopySourceControl.cs
@@ -17,7 +17,7 @@ namespace ThoughtWorks.CruiseControl.Core.Sourcecontrol
     /// </key>
     /// <example>
     /// <code>
-    /// &lt;sourcecontrol type="repositoryRoot"&gt;
+    /// &lt;sourcecontrol type="robocopy"&gt;
     /// &lt;repositoryRoot&gt;C:\Somewhere&lt;/repositoryRoot&gt;
     /// &lt;/sourcecontrol&gt;
     /// </code>


### PR DESCRIPTION
The robocopy command should be 
`<sourcecontrol type="robocopy">`
not 
`<sourcecontrol type="repositoryRoot">`
