### PR TITLE
Fix sorting in the main CCTray window

### DIFF
--- a/project/CCTrayLib/Presentation/MainForm.cs
+++ b/project/CCTrayLib/Presentation/MainForm.cs
@@ -1131,7 +1131,7 @@ namespace ThoughtWorks.CruiseControl.CCTrayLib.Presentation
         // Implements the manual sorting of items by columns.
         private class ListViewItemComparer : IComparer
         {
-            private static string[] _columnSortTypes = new string[] { "string", "string", "string", "string", "int", "datetime", "string",  "datetime","string", "string", "string" };
+            private static string[] _columnSortTypes = new string[] { "string", "string", "string", "string", "string", "string", "datetime", "string",  "string", "int" };
             private int col;
             private bool ascendingOrder;
 


### PR DESCRIPTION
The sorting column data type definitions are separated from the column definitions themselves, so any change (addition, reordering) in the columns often leads to broken sorting, which is the current state of affairs.

Currently, we have the following columns with the respective data types:

colProject  :   string
colServer   :   string
colCategory :   string
colActivity :   string
colDetail   :   int (!)
colLastBuildLabel   :   datetime (!)
colLastBuildTime    :   string (!)
colProjectStatus    :   datetime (!)
colQName    :   string
colQPriority    :   string
-nothing-   :   string (!)

Everything should be a string except for colLastBuildTime, which is datetime, and colQPriority, which is int (but probably could work also with string).
