### PR TITLE
Use SVN Switch instead of Update (Issue 245)

### DIFF
--- a/project/UnitTests/Core/SourceControl/SvnTest.cs
+++ b/project/UnitTests/Core/SourceControl/SvnTest.cs
@@ -253,7 +253,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol
 		public void ShouldGetSourceWithAppropriateRevisionNumberIfTagOnSuccessTrueAndModificationsFound()
 		{
 			ExpectSvnDirectoryExists(true);
-            ExpectToExecuteArguments(string.Format(@"update {0} --revision 10 --no-auth-cache --non-interactive", StringUtil.AutoDoubleQuoteString(DefaultWorkingDirectory)));
+            ExpectToExecuteArguments(string.Format(@"switch {0} {1} --revision 10 --no-auth-cache --non-interactive", svn.TrunkUrl, StringUtil.AutoDoubleQuoteString(DefaultWorkingDirectory)));
 
 			IIntegrationResult result = IntegrationResult();
 			Modification mod = new Modification();
@@ -271,7 +271,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol
 		public void ShouldGetSourceWithoutRevisionNumberIfTagOnSuccessTrueAndModificationsNotFound()
 		{
 			ExpectSvnDirectoryExists(true);
-            ExpectToExecuteArguments(string.Format(@"update {0} --no-auth-cache --non-interactive", StringUtil.AutoDoubleQuoteString(DefaultWorkingDirectory)));
+            ExpectToExecuteArguments(string.Format(@"switch {0} {1} --no-auth-cache --non-interactive", svn.TrunkUrl, StringUtil.AutoDoubleQuoteString(DefaultWorkingDirectory)));
 			svn.AutoGetSource = true;
 			svn.GetSource(IntegrationResult());
 		}
@@ -280,7 +280,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol
 		public void ShouldGetSourceWithCredentialsIfSpecifiedIfAutoGetSourceTrue()
 		{
 			ExpectSvnDirectoryExists(true);
-            ExpectToExecuteArguments(string.Format(@"update {0} --username ""Buck Rogers"" --password ""My Password"" --no-auth-cache --non-interactive", StringUtil.AutoDoubleQuoteString(DefaultWorkingDirectory)));
+            ExpectToExecuteArguments(string.Format(@"switch {0} {1} --username ""Buck Rogers"" --password ""My Password"" --no-auth-cache --non-interactive", svn.TrunkUrl, StringUtil.AutoDoubleQuoteString(DefaultWorkingDirectory)));
 			svn.Username = "Buck Rogers";
 			svn.Password = "My Password";
 			svn.AutoGetSource = true;
@@ -292,7 +292,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol
 		{
 			mockFileSystem.ExpectAndReturn("DirectoryExists", true, Path.Combine(DefaultWorkingDirectoryWithSpaces, ".svn"));
 
-            ExpectToExecuteArguments(string.Format(@"update {0} --no-auth-cache --non-interactive", StringUtil.AutoDoubleQuoteString(DefaultWorkingDirectoryWithSpaces)), DefaultWorkingDirectoryWithSpaces);
+            ExpectToExecuteArguments(string.Format(@"switch {0} {1} --no-auth-cache --non-interactive", svn.TrunkUrl, StringUtil.AutoDoubleQuoteString(DefaultWorkingDirectoryWithSpaces)), DefaultWorkingDirectoryWithSpaces);
 			svn.AutoGetSource = true;
 			svn.WorkingDirectory = DefaultWorkingDirectoryWithSpaces;
 			svn.GetSource(IntegrationResult());
@@ -336,7 +336,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol
 		{
 			ExpectSvnDirectoryExists(false);
 			ExpectUnderscoreSvnDirectoryExists(true);
-            ExpectToExecuteArguments(string.Format(@"update {0} --no-auth-cache --non-interactive", StringUtil.AutoDoubleQuoteString(DefaultWorkingDirectory)));
+            ExpectToExecuteArguments(string.Format(@"switch {0} {1} --no-auth-cache --non-interactive", svn.TrunkUrl, StringUtil.AutoDoubleQuoteString(DefaultWorkingDirectory)));
 
 			svn.AutoGetSource = true;
 			svn.WorkingDirectory = DefaultWorkingDirectory;

--- a/project/core/sourcecontrol/Svn.cs
+++ b/project/core/sourcecontrol/Svn.cs
@@ -735,7 +735,8 @@ namespace ThoughtWorks.CruiseControl.Core.Sourcecontrol
 
         private ProcessInfo NewGetSourceProcessInfo(IIntegrationResult result)
         {
-            var buffer = new PrivateArguments("update");
+            var buffer = new PrivateArguments("switch");
+            buffer.Add(string.Empty, TrunkUrl, true);
             buffer.Add(null, Path.GetFullPath(result.BaseFromWorkingDirectory(WorkingDirectory)), true);
             // Do not use Modification.GetLastChangeNumber() here directly.
             AppendRevision(buffer, latestRevision);


### PR DESCRIPTION
Patch for Issue 245, replacing svn update with svn switch
