### PR TITLE
Git clean should also clean submodule work trees recursively

### DIFF
--- a/project/core/sourcecontrol/Git.cs
+++ b/project/core/sourcecontrol/Git.cs
@@ -669,6 +669,16 @@ namespace ThoughtWorks.CruiseControl.Core.Sourcecontrol
             buffer.AddArgument("-f");
             buffer.AddArgument("-x");
             Execute(NewProcessInfo(buffer.ToString(), result));
+
+            if (FetchSubmodules)
+            {
+                buffer = new ProcessArgumentBuilder();
+                buffer.AddArgument("submodule");
+                buffer.AddArgument("foreach");
+                buffer.AddArgument("--recursive");
+                buffer.AddArgument("\"git clean -d -f -x\"");
+                Execute(NewProcessInfo(buffer.ToString(), result));
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Git clean should also clean submodule work trees recursively.
This performs REALLY clean build.
