### PR TITLE
CCTray: Open connection and authenticate

### DIFF
--- a/project/CCTrayLib/Presentation/MainFormController.cs
+++ b/project/CCTrayLib/Presentation/MainFormController.cs
@@ -46,6 +46,7 @@ namespace ThoughtWorks.CruiseControl.CCTrayLib.Presentation
 			for (int i = 0; i < serverMonitors.Length; i++)
 			{
 				serverMonitors[i] = new SynchronizedServerMonitor(serverMonitors[i], owner);
+                serverMonitors[i].Start();
 			}
 			aggregatedServerMonitor = new AggregatingServerMonitor(serverMonitors);
 			queueIconProvider = new ResourceIntegrationQueueIconProvider();


### PR DESCRIPTION
If your cruise control server needs authentication then you already noticed that the CCTray application does not log you in every time you restart your computer or login on windows.

With this change the CCTray application try to connect and authenticate with the Cruise control server when is loading your projects, using your previous settings.
