### PR TITLE
I have a (* no branch) after doing a checkout -q -f origin/master

### DIFF
--- a/project/core/sourcecontrol/Git.cs
+++ b/project/core/sourcecontrol/Git.cs
@@ -614,7 +614,7 @@ namespace ThoughtWorks.CruiseControl.Core.Sourcecontrol
 			buffer.AddArgument("checkout");
 			buffer.AddArgument("-q");
 			buffer.AddArgument("-f");
-			buffer.AddArgument(string.Concat("origin/", branchName));
+			buffer.AddArgument(branchName);
 
 			// initialize progress information
 			var bpi = GetBuildProgressInformation(result);


### PR DESCRIPTION
When checkout -q -f master is called everything is fine.
Is it a bug?
