### PR TITLE
Statistics value written in invariant culture

### DIFF
--- a/project/core/publishers/Statistics/StatisticsPublisher.cs
+++ b/project/core/publishers/Statistics/StatisticsPublisher.cs
@@ -212,7 +212,7 @@ namespace ThoughtWorks.CruiseControl.Core.Publishers.Statistics
                 if (statisticResult.Value == null)
                     result = string.Empty;
                 else
-                    result = System.Security.SecurityElement.Escape(statisticResult.Value.ToString());
+                    result = System.Security.SecurityElement.Escape(Convert.ToString(statisticResult.Value, CultureInfo.InvariantCulture));
 
                 el.AppendLine();
                 el.AppendFormat("  <statistic name=\"{0}\">{1}</statistic>",

--- a/project/core/publishers/Statistics/StatisticsResults.cs
+++ b/project/core/publishers/Statistics/StatisticsResults.cs
@@ -23,7 +23,7 @@ namespace ThoughtWorks.CruiseControl.Core.Publishers.Statistics
             {
                 StatisticResult statistic = this[i];
                 if (i > 0) writer.Write(", ");
-                writer.Write(statistic.Value);
+                writer.Write(Convert.ToString(statistic.Value, CultureInfo.InvariantCulture));
             }
             writer.WriteLine();
         }
@@ -100,7 +100,7 @@ namespace ThoughtWorks.CruiseControl.Core.Publishers.Statistics
                         {
                             writer.WriteStartElement("statistic");
                             writer.WriteAttributeString("name", statisticResult.StatName);
-                            writer.WriteString(Convert.ToString(statisticResult.Value, CultureInfo.CurrentCulture));
+                            writer.WriteString(Convert.ToString(statisticResult.Value, CultureInfo.InvariantCulture));
                             writer.WriteEndElement();
                         });
             writer.WriteEndElement();


### PR DESCRIPTION
The value of a statistic is now written to the XML and CSV in the
Invariant culture. These files are read by the computer, so these in
general do not handle using a different format (ex. decimal point being
a ',').
