### PR TITLE
Removed unintended change to from.SourceControlData

### DIFF
--- a/project/UnitTests/Core/SourceControl/MultiSourceControlTest.cs
+++ b/project/UnitTests/Core/SourceControl/MultiSourceControlTest.cs
@@ -202,6 +202,47 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol
         }
 
         [Test]
+        public void GetModificationsRepeatedlyShouldReturnSameResult()
+        {
+            IntegrationResult from = IntegrationResultMother.CreateSuccessful(DateTime.Now);
+            IntegrationResult to = IntegrationResultMother.CreateSuccessful(DateTime.Now.AddDays(10));
+
+            string scValue = null;
+            List<NameValuePair> list = new List<NameValuePair>();
+
+            list.Add(new NameValuePair("name0", "first"));
+            scValue = XmlConversionUtil.ConvertObjectToXml(list);
+            from.SourceControlData.Add(new NameValuePair("sc0", scValue));
+            list.Clear();
+
+            list.Add(new NameValuePair("name1", "first"));
+            list.Add(new NameValuePair("name2", "first"));
+            scValue = XmlConversionUtil.ConvertObjectToXml(list);
+            from.SourceControlData.Add(new NameValuePair("sc1", scValue));
+            list.Clear();
+
+            List<ISourceControl> sourceControls = new List<ISourceControl>();
+            sourceControls.Add(new MockSourceControl());
+            sourceControls.Add(new MockSourceControl());
+
+            MultiSourceControl multiSourceControl = new MultiSourceControl();
+            multiSourceControl.SourceControls = sourceControls.ToArray();
+
+            //// EXECUTE
+            try
+            {
+                ArrayList firstReturnedMods = new ArrayList(multiSourceControl.GetModifications(from, to));
+                ArrayList secondReturnedMods = new ArrayList(multiSourceControl.GetModifications(from, to));
+                ArrayList thirdReturnedMods = new ArrayList(multiSourceControl.GetModifications(from, to));
+                
+                Assert.AreEqual(secondReturnedMods.Count, thirdReturnedMods.Count);
+            } catch (Exception e)
+            {
+                Assert.Fail("GetModifications threw Exception:" + e.Message);
+            }
+        }
+
+        [Test]
         public void PassesIndividualSourceDataAndCombinesSingleSourceControl()
         {
             IntegrationResult from = IntegrationResultMother.CreateSuccessful(DateTime.Now);

--- a/project/core/sourcecontrol/MultiSourceControl.cs
+++ b/project/core/sourcecontrol/MultiSourceControl.cs
@@ -189,6 +189,10 @@ namespace ThoughtWorks.CruiseControl.Core.Sourcecontrol
             to.SourceControlData.Clear();
             to.SourceControlData.AddRange(finalSourceControlData);
 
+            // reset the from.SourceControlData to its original contents
+            from.SourceControlData.Clear();
+            from.SourceControlData.AddRange(originalSourceControlData);
+
             var modArray = new Modification[modificationSet.Count];
             modificationSet.Keys.CopyTo(modArray, 0);
             return modArray; 


### PR DESCRIPTION
Fixed bug where MultiSourceControl.GetModifications would leave the
from.SourceControlData changed, so the following call to
GetModifications would result in Modifications being erroneously
reported.

--- Full description -- 
While debugging some problems with CCnet and git I stumbled upon something that looks like unintended behavior, but I'm not sure if it's bad configuration or my expectations that are wrong.

I started out with the demo ccnet.config and added a multi source control block with two git repositories.
The repos are made for testing, so each one has just one text file with 2 commits. They are located locally on the same drive as CCnet is running from.
My "build" is just the ping action from the demo script.

The behavior I'm seeing is that at first integration the repos are cloned, thus there are modifications, and the build is triggered.
Second integration run there are no modifications - which is expected.
But the third run, CCnet finds that there are modifications, so the build is triggered.
From here on, it runs a steady rhythm - every other integration, CCnet sees changes and triggers the build (and the repositories are not changed).

If I have just one sourcecontrol of type git, then everything works as expected - build is only triggered when I change the repository.

As far as I can see, the method MultiSourceControl.GetModifications(IIntegrationResult from, IIntegrationResult to) modified the from.SourceControlData list, so every other time it has only 1 of the 2 actual source-control-objects, and that triggers the build. I have a tiny patch that fixes the issue and doesn't break any unit tests.

To reproduce, create two repos as 
mkdir test1; cd test1; git init; echo 123 > file.txt; git commit -m "first"; echo 321 >> file.txt; git commit -m "second"
mkdir test2; cd test2; git init; echo 123 > file.txt; git commit -m "first"; echo 321 >> file.txt; git commit -m "second"

ccnet config:
<cruisecontrol xmlns:cb="urn:ccnet.config.builder">

  <cb:define nant.exe="c:\nant\bin\nant.exe"/>
  <cb:define git.exe="C:\PortableGit\cmd\git.exe"/>

  <project name="MyFirstProject" description="demoproject showing a small config">

```
<state type="state" directory="State" />
<artifactDirectory>BuildArtifacts</artifactDirectory>

<triggers>
  <intervalTrigger       name="continuous"
               seconds="15"
               buildCondition="IfModificationExists"
               initialSeconds="5"/>
</triggers>

<sourcecontrol type="multi">
  <sourceControls>
    <git>
      <repository>C:\repo\Test1</repository>
      <branch>master</branch>
      <autoGetSource>true</autoGetSource>
      <executable>$(git.exe)</executable>
      <workingDirectory>Test1</workingDirectory>
    </git>
    <git>
      <repository>C:\repo\Test2</repository>
      <branch>master</branch>
      <autoGetSource>true</autoGetSource>
      <executable>$(git.exe)</executable>
      <workingDirectory>Test2</workingDirectory>
    </git>
  </sourceControls>
</sourcecontrol>


<tasks>
  <exec>
    <!-- if you want the task to fail, ping an unknown server -->
    <executable>ping.exe</executable>
    <buildArgs>localhost</buildArgs>
    <buildTimeoutSeconds>15</buildTimeoutSeconds>
    <description>Pinging a server</description>
  </exec>
</tasks>

<publishers>
  <xmllogger />
  <artifactcleanup cleanUpMethod="KeepLastXBuilds" cleanUpValue="50" />
</publishers>
```

  </project>
</cruisecontrol>
