### PR TITLE
Logged in user's display name is shown now

### DIFF
--- a/project/Remote/CruiseServerClient.cs
+++ b/project/Remote/CruiseServerClient.cs
@@ -542,6 +542,7 @@ namespace ThoughtWorks.CruiseControl.Remote
             if (!string.IsNullOrEmpty(resp.SessionToken))
             {
                 SessionToken = resp.SessionToken;
+                DisplayName = resp.DisplayName;
                 return true;
             }
             else

--- a/project/Remote/Messages/LoginResponse.cs
+++ b/project/Remote/Messages/LoginResponse.cs
@@ -15,6 +15,7 @@ namespace ThoughtWorks.CruiseControl.Remote.Messages
     {
         #region Private fields
         private string sessionToken;
+        private string displayName;
         #endregion
 
         #region Constructors
@@ -55,6 +56,18 @@ namespace ThoughtWorks.CruiseControl.Remote.Messages
         {
             get { return sessionToken; }
             set { sessionToken = value; }
+        }
+        #endregion
+
+        #region DisplayName
+        /// <summary>
+        /// The display name of the user.
+        /// </summary>
+        [XmlAttribute("displayName")]
+        public string DisplayName
+        {
+            get { return displayName; }
+            set { displayName = value; }
         }
         #endregion
         #endregion

--- a/project/WebDashboard/Dashboard/CookieSessionStore.cs
+++ b/project/WebDashboard/Dashboard/CookieSessionStore.cs
@@ -58,6 +58,28 @@ namespace ThoughtWorks.CruiseControl.WebDashboard.Dashboard
 		}
 		#endregion
 
+        #region DisplayName
+        /// <summary>
+        /// Stores the display name in a cookie or deletes the cookie.
+        /// </summary>
+        public void StoreDisplayName(string displayName)
+        {
+            HttpContext.Current.Session["CCNetDisplayName"] = displayName;
+        }
+        #endregion
+
+        #region RetrieveDisplayName()
+        /// <summary>
+        /// Retrieve the display name.
+        /// </summary>
+        /// <param name="request"></param>
+        /// <returns></returns>
+        public string RetrieveDisplayName(IRequest request)
+        {
+            return (String)HttpContext.Current.Session["CCNetDisplayName"];
+        }
+        #endregion
+
 		#endregion
 	}
 }

--- a/project/WebDashboard/Dashboard/ISessionRetriever.cs
+++ b/project/WebDashboard/Dashboard/ISessionRetriever.cs
@@ -13,5 +13,12 @@ namespace ThoughtWorks.CruiseControl.WebDashboard.Dashboard
         /// <param name="request"></param>
         /// <returns></returns>
         string RetrieveSessionToken(IRequest request);
+
+        /// <summary>
+        /// Retrieves the display name from a request.
+        /// </summary>
+        /// <param name="request"></param>
+        /// <returns></returns>
+        string RetrieveDisplayName(IRequest request);
     }
 }

--- a/project/WebDashboard/Dashboard/LoginViewBuilder.cs
+++ b/project/WebDashboard/Dashboard/LoginViewBuilder.cs
@@ -63,7 +63,12 @@ namespace ThoughtWorks.CruiseControl.WebDashboard.Dashboard
                         "Change Password",
                         ChangePasswordSecurityAction.ActionName);
 
-                    userName = sessionToken;
+                    string displayName = retriever.RetrieveDisplayName(request.Request);
+
+                    if (string.IsNullOrEmpty(displayName))
+                        userName = sessionToken;
+                    else
+                        userName = displayName;
                 }
 
                 velocityContext["userName"] = userName;

--- a/project/WebDashboard/Plugins/Security/LogoutSecurityAction.cs
+++ b/project/WebDashboard/Plugins/Security/LogoutSecurityAction.cs
@@ -41,6 +41,7 @@ namespace ThoughtWorks.CruiseControl.WebDashboard.Plugins.Security
 			if (!string.IsNullOrEmpty(sessionToken))
 				farmService.Logout(cruiseRequest.ServerName, sessionToken);
 			storer.StoreSessionToken(null);
+			storer.StoreDisplayName(null);
 			return viewGenerator.GenerateView("LoggedOut.vm", velocityContext);
 		}
 		#endregion

--- a/project/WebDashboard/Plugins/Security/UserNameSecurityAction.cs
+++ b/project/WebDashboard/Plugins/Security/UserNameSecurityAction.cs
@@ -49,6 +49,7 @@ namespace ThoughtWorks.CruiseControl.WebDashboard.Plugins.Security
                     string sessionToken = farmService.Login(cruiseRequest.ServerName, credentials);
                     if (string.IsNullOrEmpty(sessionToken)) throw new CruiseControlException("Login failed!");
                     storer.StoreSessionToken(sessionToken);
+                    storer.StoreDisplayName(farmService.GetDisplayName(cruiseRequest.ServerName, sessionToken));
                     template = "LoggedIn.vm";
                 }
                 catch (Exception error)

--- a/project/WebDashboard/ServerConnection/IFarmService.cs
+++ b/project/WebDashboard/ServerConnection/IFarmService.cs
@@ -35,6 +35,7 @@ namespace ThoughtWorks.CruiseControl.WebDashboard.ServerConnection
         void Logout(string server, string sessionToken);
         void ChangePassword(string server, string sessionToken, string oldPassword, string newPassword);
         void ResetPassword(string server, string sessionToken, string userName, string newPassword);
+        string GetDisplayName(string server, string sessionToken);
 
         /// <summary>
         /// Retrieves the configuration for security on a server.

--- a/project/WebDashboard/ServerConnection/ServerAggregatingCruiseManagerWrapper.cs
+++ b/project/WebDashboard/ServerConnection/ServerAggregatingCruiseManagerWrapper.cs
@@ -323,6 +323,11 @@ namespace ThoughtWorks.CruiseControl.WebDashboard.ServerConnection
             GetCruiseManager(GetServerConfiguration(server), sessionToken).Logout();
 		}
 
+        public string GetDisplayName(string server, string sessionToken)
+        {
+            return GetCruiseManager(GetServerConfiguration(server), sessionToken).DisplayName;
+        }
+
         /// <summary>
         /// Changes the current user's password.
         /// </summary>

--- a/project/core/CruiseServer.cs
+++ b/project/core/CruiseServer.cs
@@ -1121,13 +1121,16 @@ namespace ThoughtWorks.CruiseControl.Core
         public virtual LoginResponse Login(LoginRequest request)
         {
             string sessionToken = null;
+            string displayName = null;
             LoginResponse response = new LoginResponse(RunServerRequest(request,
                 null,
                 null,
                 delegate {
                     sessionToken = securityManager.Login(request);
+                    displayName = securityManager.GetDisplayName(sessionToken, null);
                 }));
             response.SessionToken = sessionToken;
+            response.DisplayName = displayName;
             return response;
         }
         #endregion

--- a/project/core/Reporting/Dashboard/Navigation/ISessionStorer.cs
+++ b/project/core/Reporting/Dashboard/Navigation/ISessionStorer.cs
@@ -9,5 +9,10 @@
         /// The session token to store, null to delete.
         /// </summary>
 		void StoreSessionToken(string sessionToken);
+
+        /// <summary>
+        /// The display name to store, null to delete.
+        /// </summary>
+        void StoreDisplayName(string displayName);
     }
 }


### PR DESCRIPTION
After user has log-in, session token was shown in top left corner.
That's now changed to display the user's display name
