### PR TITLE
Git Source control section has been extended with a new configuration parameter cleanUntrackedFiles. 

### DIFF
--- a/project/core/sourcecontrol/Git.cs
+++ b/project/core/sourcecontrol/Git.cs
@@ -320,13 +320,13 @@ namespace ThoughtWorks.CruiseControl.Core.Sourcecontrol
 			// checkout remote branch
 			GitCheckoutRemoteBranch(Branch, result);
 
-            // update submodules
-            if (FetchSubmodules)
-                GitUpdateSubmodules(result);
+			// update submodules
+			if (FetchSubmodules)
+				GitUpdateSubmodules(result);
 
 			// clean up the local working copy
-      if (CleanUntrackedFiles)
-			  GitClean(result);
+			if (CleanUntrackedFiles)
+				GitClean(result);
 		}
 
         /// <summary>


### PR DESCRIPTION
The purpose of this parameter is to avoid invocation of the command "git clean -d -f -x" during continue integration builds. You may want to use this trick for incremental builds when you don't want to delete compiled files after each sequential project.
Default value is true. It corresponds to default behavior
