### PR TITLE
use UTF8 for outputstream of git.exe

### DIFF
--- a/project/core/sourcecontrol/Git.cs
+++ b/project/core/sourcecontrol/Git.cs
@@ -461,7 +461,7 @@ namespace ThoughtWorks.CruiseControl.Core.Sourcecontrol
             Log.Info(string.Concat("[Git] Calling git ", args));
             var processInfo = new ProcessInfo(Executable, args, BaseWorkingDirectory(result), priority,
                                                       successExitCodes);
-            //processInfo.StreamEncoding = Encoding.UTF8;
+            processInfo.StreamEncoding = Encoding.UTF8;
             return processInfo;
         }
 


### PR DESCRIPTION
From msysGit 1.7.10 in 2012, git.exe became to treat UTF8 encoding.
The line "//processInfo.StreamEncoding = Encoding.UTF8;" was comment-outed in 2009, so it should be enabled nowadays.

Especially in Japan, if someone use their Japanese name as AuthorName,
then parsing log from git.exe always fails.

In other words, if someone use their Japanese name and push his change to repository, it will crash the environment of continuous integration.
It is a terrible situation.
