### PR TITLE
Update NetReflectorConfigurationReader.cs

### DIFF
--- a/project/core/Config/NetReflectorConfigurationReader.cs
+++ b/project/core/Config/NetReflectorConfigurationReader.cs
@@ -33,7 +33,7 @@ namespace ThoughtWorks.CruiseControl.Core.Config
 		{
 			typeTable = new NetReflectorTypeTable();
 			typeTable.Add(AppDomain.CurrentDomain);
-            string pluginLocation = ConfigurationManager.AppSettings["PluginLocation"];
+            string pluginLocation = Environment.ExpandEnvironmentVariables(ConfigurationManager.AppSettings["PluginLocation"]);
             if (!string.IsNullOrEmpty(pluginLocation))
             {
                 if (Directory.Exists(pluginLocation))


### PR DESCRIPTION
Allows users to enter an environmental variable in the path for the plugin location.
