### PR TITLE
Mercurial local tags

### DIFF
--- a/project/CommonAssemblyInfo.cs
+++ b/project/CommonAssemblyInfo.cs
@@ -14,6 +14,5 @@ using System.Reflection;
 [assembly: AssemblyProductAttribute("CruiseControl.NET")]
 [assembly: AssemblyCopyrightAttribute("Copyright © 2003 - 2013 ThoughtWorks Inc.")]
 [assembly: AssemblyTrademarkAttribute("")]
-[assembly: AssemblyVersionAttribute("1.8.4.99")]
-[assembly: AssemblyFileVersionAttribute("1.8.4.99")]
+[assembly: AssemblyVersionAttribute("1.8.4.*")]
 

--- a/project/CommonAssemblyInfo.cs
+++ b/project/CommonAssemblyInfo.cs
@@ -14,6 +14,6 @@ using System.Reflection;
 [assembly: AssemblyProductAttribute("CruiseControl.NET")]
 [assembly: AssemblyCopyrightAttribute("Copyright © 2003 - 2013 ThoughtWorks Inc.")]
 [assembly: AssemblyTrademarkAttribute("")]
-[assembly: AssemblyVersionAttribute("0.0.0.0")]
-[assembly: AssemblyFileVersionAttribute("0.0.0.0")]
+[assembly: AssemblyVersionAttribute("1.8.4.99")]
+[assembly: AssemblyFileVersionAttribute("1.8.4.99")]
 

--- a/project/core/sourcecontrol/Mercurial/Mercurial.cs
+++ b/project/core/sourcecontrol/Mercurial/Mercurial.cs
@@ -204,6 +204,14 @@ namespace ThoughtWorks.CruiseControl.Core.Sourcecontrol.Mercurial
 		public bool TagOnSuccess { get; set; }
 
 		/// <summary>
+		/// Indicates that the tag should be created locally.
+		/// </summary>
+		/// <version>1.8</version>
+		/// <default>false</default>
+		[ReflectorProperty("tagLocal", Required = false)]
+		public bool TagLocal { get; set; }
+
+		/// <summary>
 		/// String format for tags in your repository.
 		/// </summary>
 		/// <version>1.6</version>
@@ -749,6 +757,10 @@ namespace ThoughtWorks.CruiseControl.Core.Sourcecontrol.Mercurial
 			if(!string.IsNullOrEmpty(CommitterName))
 			{
 				buffer.AddArgument("-u", CommitterName);
+			}
+			if( TagLocal ) 
+			{
+				buffer.AddArgument( "-l" );
 			}
 
 			buffer.AddArgument("-f");

--- a/project/core/sourcecontrol/Mercurial/Mercurial.cs
+++ b/project/core/sourcecontrol/Mercurial/Mercurial.cs
@@ -156,6 +156,14 @@ namespace ThoughtWorks.CruiseControl.Core.Sourcecontrol.Mercurial
 		public string Branch { get; set; }
 
 		/// <summary>
+		/// Repository bookmark.
+		/// </summary>
+		/// <version>1.8</version>
+		/// <default>None</default>
+		[ReflectorProperty("bookmark", Required = false)]
+		public string Bookmark { get; set; }
+
+		/// <summary>
 		/// User name used for commits.
 		/// </summary>
 		/// <version>1.6</version>
@@ -568,6 +576,10 @@ namespace ThoughtWorks.CruiseControl.Core.Sourcecontrol.Mercurial
 				buffer.AddArgument("-b", Branch);
 				buffer.AddArgument("-r", Branch);
 			}
+			else if(!string.IsNullOrEmpty(Bookmark))
+			{
+				buffer.AddArgument("-r", Bookmark);
+			}
 			else
 			{
 				buffer.AddArgument("-r", "tip");
@@ -636,6 +648,10 @@ namespace ThoughtWorks.CruiseControl.Core.Sourcecontrol.Mercurial
 			{
 				buffer.AddArgument("-b", Branch);
 			}
+			if(!string.IsNullOrEmpty(Bookmark))
+			{
+				buffer.AddArgument("-B", Bookmark);
+			}
 
 			buffer.AddArgument(Repository);
 
@@ -662,7 +678,11 @@ namespace ThoughtWorks.CruiseControl.Core.Sourcecontrol.Mercurial
 			ProcessArgumentBuilder buffer = new ProcessArgumentBuilder();
 			buffer.AddArgument("update");
 
-			if(!string.IsNullOrEmpty(Branch))
+			if(!string.IsNullOrEmpty(Bookmark))
+			{
+				buffer.AddArgument(Bookmark);
+			}
+			else if(!string.IsNullOrEmpty(Branch))
 			{
 				buffer.AddArgument(Branch);
 			}
@@ -792,6 +812,10 @@ namespace ThoughtWorks.CruiseControl.Core.Sourcecontrol.Mercurial
 			if(!string.IsNullOrEmpty(Branch))
 			{
 				buffer.AddArgument("-b", Branch);
+			}
+			if(!string.IsNullOrEmpty(Bookmark))
+			{
+				buffer.AddArgument("-B", Bookmark);
 			}
 
 			buffer.AddArgument("-f");


### PR DESCRIPTION
Added support for local tags on Mercurial.
Set the TagLocal property to true in the <sourcecontrol> element of the
configuration file to enable local tagging.