### PR TITLE
New parameter type PasswordParameter

### DIFF
--- a/project/CCTrayLib/Presentation/BuildParameters.cs
+++ b/project/CCTrayLib/Presentation/BuildParameters.cs
@@ -1,7 +1,6 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Drawing;
 using System.Reflection;
 using System.Reflection.Emit;
 using System.Text;
@@ -142,6 +141,7 @@ namespace ThoughtWorks.CruiseControl.CCTrayLib.Presentation
             getGenerator.Emit(OpCodes.Ldarg_0);
             getGenerator.Emit(OpCodes.Ldfld, fieldBuilder);
             getGenerator.Emit(OpCodes.Ret);
+            
             MethodBuilder propertySetBuilder = typeBuilder.DefineMethod("get_" + parameter.Name,
                 MethodAttributes.Public | MethodAttributes.SpecialName | MethodAttributes.HideBySig,
                 null,
@@ -153,6 +153,12 @@ namespace ThoughtWorks.CruiseControl.CCTrayLib.Presentation
             setGenerator.Emit(OpCodes.Ret);
             AssociateAttribute(propertyBuilder, typeof(DescriptionAttribute), parameter.Description);
             AssociateAttribute(propertyBuilder, typeof(DisplayNameAttribute), parameter.DisplayName);
+
+            if (parameter.ParameterType == "Password")
+            {
+                AssociateAttribute(propertyBuilder, typeof(PasswordPropertyTextAttribute), true);
+            }
+            
             propertyBuilder.SetGetMethod(propertyGetBuilder);
             propertyBuilder.SetSetMethod(propertySetBuilder);
         }
@@ -172,6 +178,14 @@ namespace ThoughtWorks.CruiseControl.CCTrayLib.Presentation
         {
             CustomAttributeBuilder attributeBuilder = new CustomAttributeBuilder(
                 attributeType.GetConstructor(new Type[] { typeof(string) }),
+                new object[] { value });
+            propertyBuilder.SetCustomAttribute(attributeBuilder);
+        }
+
+        private void AssociateAttribute(PropertyBuilder propertyBuilder, Type attributeType, bool value)
+        {
+            CustomAttributeBuilder attributeBuilder = new CustomAttributeBuilder(
+                attributeType.GetConstructor(new Type[] { typeof(bool) }),
                 new object[] { value });
             propertyBuilder.SetCustomAttribute(attributeBuilder);
         }

--- a/project/Remote/Parameters/BooleanParameter.cs
+++ b/project/Remote/Parameters/BooleanParameter.cs
@@ -154,7 +154,7 @@ namespace ThoughtWorks.CruiseControl.Remote.Parameters
 
         #region DataType
         /// <summary>
-        /// The type of the parameter.
+        /// The data type of the parameter.
         /// </summary>
         public override Type DataType
         {

--- a/project/Remote/Parameters/BooleanParameter.cs
+++ b/project/Remote/Parameters/BooleanParameter.cs
@@ -162,6 +162,16 @@ namespace ThoughtWorks.CruiseControl.Remote.Parameters
         }
         #endregion
 
+        #region ParameterType
+        /// <summary>
+        /// The type of the parameter.
+        /// </summary>
+        public override string ParameterType
+        {
+            get { return "Boolean"; }
+        }
+        #endregion
+
         #region AllowedValues
         /// <summary>
         /// An array of allowed values.

--- a/project/Remote/Parameters/DateParameter.cs
+++ b/project/Remote/Parameters/DateParameter.cs
@@ -162,6 +162,16 @@ namespace ThoughtWorks.CruiseControl.Remote.Parameters
         }
         #endregion
 
+        #region ParameterType
+        /// <summary>
+        /// The type of the parameter.
+        /// </summary>
+        public override string ParameterType
+        {
+            get { return "Date"; }
+        }
+        #endregion
+
         #region AllowedValues
         /// <summary>
         /// An array of allowed values.

--- a/project/Remote/Parameters/DateParameter.cs
+++ b/project/Remote/Parameters/DateParameter.cs
@@ -154,7 +154,7 @@ namespace ThoughtWorks.CruiseControl.Remote.Parameters
 
         #region DataType
         /// <summary>
-        /// The type of the parameter.
+        /// The data type of the parameter.
         /// </summary>
         public override Type DataType
         {

--- a/project/Remote/Parameters/NumericParameter.cs
+++ b/project/Remote/Parameters/NumericParameter.cs
@@ -141,12 +141,22 @@ namespace ThoughtWorks.CruiseControl.Remote.Parameters
         }
 
         /// <summary>
-        /// The type of the parameter.
+        /// The data type of the parameter.
         /// </summary>
         public override Type DataType
         {
             get { return typeof(double); }
         }
+
+        #region ParameterType
+        /// <summary>
+        /// The type of the parameter.
+        /// </summary>
+        public override string ParameterType
+        {
+            get { return "Numeric"; }
+        }
+        #endregion
 
         /// <summary>
         /// An array of allowed values.

--- a/project/Remote/Parameters/ParameterBase.cs
+++ b/project/Remote/Parameters/ParameterBase.cs
@@ -16,6 +16,7 @@ namespace ThoughtWorks.CruiseControl.Remote.Parameters
     [XmlInclude(typeof(NumericParameter))]
     [XmlInclude(typeof(DateParameter))]
     [XmlInclude(typeof(BooleanParameter))]
+    [XmlInclude(typeof(PasswordParameter))]
     public abstract class ParameterBase
     {
         #region Private fields

--- a/project/Remote/Parameters/ParameterBase.cs
+++ b/project/Remote/Parameters/ParameterBase.cs
@@ -1,4 +1,4 @@
-﻿#if !NoReflector
+#if !NoReflector
 using Exortech.NetReflector;
 #endif
 using System;
@@ -20,6 +20,7 @@ namespace ThoughtWorks.CruiseControl.Remote.Parameters
     {
         #region Private fields
         private string myName;
+        private string myParameterType = null;
         private string myDisplayName = null;
         private string myDescription = null;
         private string myDefault = null;
@@ -125,9 +126,26 @@ namespace ThoughtWorks.CruiseControl.Remote.Parameters
 
         #region DataType
         /// <summary>
-        /// The type of the parameter.
+        /// The data type of the parameter.
         /// </summary>
         public abstract Type DataType { get; }
+        #endregion
+
+        #region ParameterType
+        /// <summary>
+        /// The type of the parameter.
+        /// </summary>
+        /// <version>1.0</version>
+        /// <default>None</default>
+#if !NoReflector
+        [ReflectorProperty("type", Required = false)]
+#endif
+        [XmlAttribute("type")]
+        public virtual string ParameterType
+        {
+            get { return myParameterType; }
+            set { myParameterType = value; }
+        }
         #endregion
 
         #region AllowedValues

--- a/project/Remote/Parameters/PasswordParameter.cs
+++ b/project/Remote/Parameters/PasswordParameter.cs
@@ -1,0 +1,204 @@
+#if !NoReflector
+using Exortech.NetReflector;
+#endif
+using System;
+using System.Collections.Generic;
+using System.Xml.Serialization;
+using System.ComponentModel;
+
+namespace ThoughtWorks.CruiseControl.Remote.Parameters
+{
+    /// <title>Password Parameter</title>
+    /// <version>1.0</version>
+    /// <summary>
+    /// <para>
+    /// This will prompt the user to enter a masked text value when a force build is requested.
+    /// </para>
+    /// <para>
+    /// This parameter can then be used by a dynamic value in a task.
+    /// </para>
+    /// </summary>
+    /// <example>
+    /// <code title="Minimalist example">
+    /// &lt;passwordParameter&gt;
+    /// &lt;name&gt;Target&lt;/name&gt;
+    /// &lt;/passwordParameter&gt;
+    /// </code>
+    /// <code title="Full example">
+    /// &lt;passwordParameter&gt;
+    /// &lt;name&gt;Password&lt;/name&gt;
+    /// &lt;display&gt;User password&lt;/display&gt;
+    /// &lt;description&gt;Enter your account password&lt;/description&gt;
+    /// &lt;default&gt;Password123&lt;/default&gt;
+    /// &lt;minimum&gt;3&lt;/minimum&gt;
+    /// &lt;maximum&gt;18&lt;/maximum&gt;
+    /// &lt;required&gt;false&lt;/required&gt;
+    /// &lt;/passwordParameter&gt;
+    /// </code>
+    /// <code title="Example in Context">
+    /// &lt;project name="Test Project"&gt;
+    /// &lt;sourcecontrol type="svn"&gt;
+    /// &lt;!-- Omitted for brevity --&gt;
+    /// &lt;/sourcecontrol&gt;
+    /// &lt;triggers&gt;
+    /// &lt;intervalTrigger /&gt;
+    /// &lt;/triggers&gt;
+    /// &lt;tasks&gt;
+    /// &lt;!-- Omitted for brevity --&gt;
+    /// &lt;/tasks&gt;
+    /// &lt;publishers&gt;
+    /// &lt;!-- Omitted for brevity --&gt;
+    /// &lt;/publishers&gt;
+    /// &lt;parameters&gt;
+    /// &lt;passwordParameter&gt;
+    /// &lt;name&gt;Password&lt;/name&gt;
+    /// &lt;display&gt;User password&lt;/display&gt;
+    /// &lt;description&gt;Enter your account password&lt;/description&gt;
+    /// &lt;default&gt;Password123&lt;/default&gt;
+    /// &lt;minimum&gt;3&lt;/minimum&gt;
+    /// &lt;maximum&gt;18&lt;/maximum&gt;
+    /// &lt;required&gt;false&lt;/required&gt;
+    /// &lt;/passwordParameter&gt;
+    /// &lt;/parameters&gt;
+    /// &lt;/project&gt;
+    /// </code>
+    /// </example>
+#if !NoReflector
+    [ReflectorType("passwordParameter")]
+#endif
+    [XmlRoot("passwordParameter")]
+    [Serializable]
+    public class PasswordParameter
+        : ParameterBase
+    {
+        #region Private fields
+        private int myMinLength/* = 0*/;
+        private int myMaxLength = int.MaxValue;
+        private bool myIsRequired/* = false*/;
+        #endregion
+
+        #region Constructors
+        /// <summary>
+        /// Initialise a new instance of a <see cref="PasswordParameter"/>.
+        /// </summary>
+        public PasswordParameter()
+            : base()
+        {
+        }
+
+        /// <summary>
+        /// Initialise an instance of a <see cref="PasswordParameter"/> with a name.
+        /// </summary>
+        public PasswordParameter(string name)
+            : base(name)
+        {
+        }
+        #endregion
+
+        /// <summary>
+        /// The minimum allowed length.
+        /// </summary>
+        /// <version>1.5</version>
+        /// <default>0</default>
+#if !NoReflector
+        [ReflectorProperty("minimum", Required = false)]
+#endif
+        [XmlAttribute("minimum")]
+        [DefaultValue(0)]
+        public virtual int MinimumLength
+        {
+            get { return myMinLength; }
+            set { myMinLength = value; }
+        }
+
+        /// <summary>
+        /// The maximum allowed length of the parameter.
+        /// </summary>
+        /// <version>1.5</version>
+        /// <default>2147483647</default>
+#if !NoReflector
+        [ReflectorProperty("maximum", Required = false)]
+#endif
+        [XmlAttribute("maximum")]
+        [DefaultValue(int.MaxValue)]
+        public virtual int MaximumLength
+        {
+            get { return myMaxLength; }
+            set { myMaxLength = value; }
+        }
+
+        /// <summary>
+        /// Is the parameter required?
+        /// </summary>
+        /// <version>1.5</version>
+        /// <default>false</default>
+#if !NoReflector
+        [ReflectorProperty("required", Required = false)]
+#endif
+        [XmlAttribute("required")]
+        [DefaultValue(false)]
+        public virtual bool IsRequired
+        {
+            get { return myIsRequired; }
+            set { myIsRequired = value; }
+        }
+
+        /// <summary>
+        /// The type of the parameter.
+        /// </summary>
+        public override Type DataType
+        {
+            get { return typeof(string); }
+        }
+
+        #region ParameterType
+        /// <summary>
+        /// The type of the parameter.
+        /// </summary>
+        public override string ParameterType
+        {
+            get { return "Password"; }
+        }
+        #endregion
+
+        /// <summary>
+        /// An array of allowed values.
+        /// </summary>
+        public override string[] AllowedValues
+        {
+            get { return null; }
+        }
+
+        /// <summary>
+        /// Validates the parameter.
+        /// </summary>
+        /// <param name="value">The value to check.</param>
+        /// <returns>Any validation exceptions.</returns>
+        public override Exception[] Validate(string value)
+        {
+            List<Exception> exceptions = new List<Exception>();
+
+            if (string.IsNullOrEmpty(value))
+            {
+                if (IsRequired) exceptions.Add(GenerateException("Value of '{name}' is required"));
+            }
+            else
+            {
+                if (value.Length < myMinLength)
+                {
+                    exceptions.Add(
+                        GenerateException("Value of '{name}' is less than the minimum length ({0})",
+                                myMinLength));
+                }
+                if (value.Length > myMaxLength)
+                {
+                    exceptions.Add(
+                        GenerateException("Value of '{name}' is more than the maximum length ({0})",
+                                myMaxLength));
+                }
+            }
+
+            return exceptions.ToArray();
+        }
+    }
+}

--- a/project/Remote/Parameters/SelectParameter.cs
+++ b/project/Remote/Parameters/SelectParameter.cs
@@ -126,11 +126,21 @@ namespace ThoughtWorks.CruiseControl.Remote.Parameters
 
         #region DataType
         /// <summary>
-        /// The type of the parameter.
+        /// The data type of the parameter.
         /// </summary>
         public override Type DataType
         {
             get { return typeof(string); }
+        }
+        #endregion
+
+        #region ParameterType
+        /// <summary>
+        /// The type of the parameter.
+        /// </summary>
+        public override string ParameterType
+        {
+            get { return "Select"; }
         }
         #endregion
 

--- a/project/Remote/Parameters/TextParameter.cs
+++ b/project/Remote/Parameters/TextParameter.cs
@@ -151,6 +151,16 @@ namespace ThoughtWorks.CruiseControl.Remote.Parameters
             get { return typeof(string); }
         }
 
+        #region ParameterType
+        /// <summary>
+        /// The type of the parameter.
+        /// </summary>
+        public override string ParameterType
+        {
+            get { return "Text"; }
+        }
+        #endregion
+
         /// <summary>
         /// An array of allowed values.
         /// </summary>

--- a/project/UnitTests/IntegrationTests/Data/DynamicValues.PrivateString.xml
+++ b/project/UnitTests/IntegrationTests/Data/DynamicValues.PrivateString.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <cruisecontrol xmlns="http://thoughtworks.org/ccnet/1/6" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <project name="Test Project">
     <webURL>xxx</webURL>
@@ -17,9 +17,9 @@
       <textParameter name="Username">
         <description>Username</description>
       </textParameter>
-      <textParameter name="Password">
+      <passwordParameter name="Password">
         <description>Password</description>
-      </textParameter>
+      </passwordParameter>
     </parameters>
   </project>
 </cruisecontrol>

--- a/project/WebDashboard/templates/ProjectParameters.vm
+++ b/project/WebDashboard/templates/ProjectParameters.vm
@@ -19,10 +19,18 @@
             #end
           </select>
         #else
-          #if ($parameter.ClientDefaultValue.Length > 0)
-          <input type="text" name="param_$parameter.Name" value="$parameter.ClientDefaultValue"/>
+          #if ($parameter.ParameterType == "Password")
+            #if ($parameter.ClientDefaultValue.Length > 0)
+            <input type="password" name="param_$parameter.Name" value="$parameter.ClientDefaultValue"/>
+            #else
+            <input type="password" name="param_$parameter.Name"/>
+            #end
           #else
-          <input type="text" name="param_$parameter.Name"/>
+            #if ($parameter.ClientDefaultValue.Length > 0)
+              <input type="text" name="param_$parameter.Name" value="$parameter.ClientDefaultValue"/>
+            #else
+            <input type="text" name="param_$parameter.Name"/>
+            #end
           #end
         #end
       </td>

--- a/project/ccnet.xsd
+++ b/project/ccnet.xsd
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <xs:schema targetNamespace="http://thoughtworks.org/ccnet/1/6"
            elementFormDefault="qualified"
            xmlns="http://thoughtworks.org/ccnet/1/6"
@@ -674,6 +674,14 @@
           </xs:documentation>
         </xs:annotation>
       </xs:element>
+      <xs:element name="passwordParameter" type="passwordParameter">
+        <xs:annotation>
+          <xs:documentation>
+            This will prompt the user to enter a masked text value when a force build is requested.
+            This parameter can then be used by a dynamic value in a task.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
     </xs:choice>
   </xs:complexType>
 
@@ -947,6 +955,59 @@
     </xs:attribute>
   </xs:complexType>
 
+  <xs:complexType name="passwordParameter">
+    <xs:all>
+      <xs:element name="minimum" type="xs:int" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            The minimum allowed length.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="maximum" type="xs:int" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            The maximum allowed length of the parameter.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="required" type="xs:boolean" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            Is the parameter required?
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="display" type="String" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            The display name of the parameter.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="description" type="String" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            The description of the parameter.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="default" type="String" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>
+            The default value to use.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:all>
+    <xs:attribute name="name" type="String" use="required">
+      <xs:annotation>
+        <xs:documentation>
+          The name of the parameter.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
   <xs:complexType name="Labeller" abstract="true"/>
 
   <xs:complexType name="assemblyVersionLabeller">


### PR DESCRIPTION
Allows users to use masked data entry fields for text entry. Updated ParameterBase with new public property: ParameterType. Updated the WebDashBoard and CCTray to support password fields for parameters of this type.
