### PR TITLE
Queue: Implementing a maximum size restriction per queue

### DIFF
--- a/project/core/Config/DefaultQueueConfiguration.cs
+++ b/project/core/Config/DefaultQueueConfiguration.cs
@@ -92,6 +92,7 @@ namespace ThoughtWorks.CruiseControl.Core.Config
         private string name;
         private QueueDuplicateHandlingMode handlingMode = QueueDuplicateHandlingMode.UseFirst;
         private string lockQueueNames;
+		private int maxSize = int.MaxValue;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DefaultQueueConfiguration"/> class.
@@ -142,6 +143,18 @@ namespace ThoughtWorks.CruiseControl.Core.Config
         {
             get { return lockQueueNames; }
             set { lockQueueNames = value; }
+        }
+		
+		/// <summary>
+        /// The maximum number of items that can be exist in the queue.
+        /// </summary>
+        /// <default>none</default>
+        /// <version>1.4.2</version>
+        [ReflectorProperty("maxsize", Required = false)]
+        public virtual int MaxSize
+        {
+            get { return maxSize; }
+            set { maxSize = value; }
         }
 
         /// <summary>

--- a/project/core/Config/IQueueConfiguration.cs
+++ b/project/core/Config/IQueueConfiguration.cs
@@ -21,6 +21,11 @@ namespace ThoughtWorks.CruiseControl.Core.Config
         /// A list of the names of any other queues which should be locked when a project in this queue is building.
         /// </summary>
         string LockQueueNames { get; set; }
+		
+		/// <summary>
+        /// The maximum size of the the queue
+        /// </summary>
+        int MaxSize { get; set; }
 
         /// <summary>
         /// Gets or sets the projects.

--- a/project/core/Queues/IntegrationQueue.cs
+++ b/project/core/Queues/IntegrationQueue.cs
@@ -90,6 +90,10 @@ namespace ThoughtWorks.CruiseControl.Core.Queues
 					// We can start integration straight away as first in first served
 					AddToQueue(integrationQueueItem);
 				}
+				else if ( Count >= configuration.MaxSize )
+				{
+					throw new ConfigurationException(string.Format("Project '{0}' cannot be added to queue '{1}' as the queue is full", integrationQueueItem.Project.Name, Name));
+				}
 				else
 				{
 					// We need to see if we already have a integration request for this project on the queue


### PR DESCRIPTION
We've found the need to cap the number of builds that can be forced onto a queue quite a handy addition