### PR TITLE
Updated XSL for ReportGenerator

### DIFF
--- a/project/xsl/ReportGenerator.xsl
+++ b/project/xsl/ReportGenerator.xsl
@@ -52,7 +52,7 @@
           Coverage:
         </td>
         <td>
-          <xsl:value-of select="Summary/Coverage"/>
+          <xsl:value-of select="format-number(Summary/Coveredlines div Summary/Coverablelines, '0.0%')"/>
         </td>
       </tr>
       <tr>

--- a/project/xsl/ReportGeneratorSummary.xsl
+++ b/project/xsl/ReportGeneratorSummary.xsl
@@ -36,14 +36,14 @@
 					Total
 				</td>
 				<td class="header-label">
-					<xsl:value-of select="Summary/Coverage"/>
+					<xsl:value-of select="format-number(Summary/Coveredlines div Summary/Coverablelines, '0.0%')"/>
 				</td>
 				<td class="header-label">
 					95%
 				</td>
 				<td class="header-label">
           <xsl:choose>
-            <xsl:when test="substring-before(Summary/Coverage,'%') &lt; 95">
+            <xsl:when test="(Summary/Coveredlines div Summary/Coverablelines) &lt; 0.95">
               <span style="color:red">FAIL</span>
             </xsl:when>
             <xsl:otherwise>


### PR DESCRIPTION
The newer releases of ReportGenerator have summary values in LineCoverage/BranchCoverage instead of Coverage. Calculate the value directly in the XSL to work with both variants.