### PR TITLE
Workaround for Git for Windows 2.x

### DIFF
--- a/project/UnitTests/Core/SourceControl/GitTest.cs
+++ b/project/UnitTests/Core/SourceControl/GitTest.cs
@@ -265,7 +265,21 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol
 
 		private void ExpectToExecuteWithArgumentsAndReturn(string args, ProcessResult returnValue)
 		{
-			mockProcessExecutor.ExpectAndReturn("Execute", returnValue, NewProcessInfo(args, DefaultWorkingDirectory));
+			var processInfo = NewProcessInfo(args, DefaultWorkingDirectory);
+			processInfo.StandardInputContent = "";
+			mockProcessExecutor.ExpectAndReturn("Execute", returnValue, processInfo);
+		}
+
+		private new void ExpectToExecuteArguments(string args)
+		{
+			ExpectToExecuteArguments(args, DefaultWorkingDirectory);
+		}
+
+		protected new void ExpectToExecuteArguments(string args, string workingDirectory)
+		{
+			ProcessInfo processInfo = NewProcessInfo(args, workingDirectory);
+			processInfo.StandardInputContent = "";
+			ExpectToExecute(processInfo);
 		}
 
 		[Test]

--- a/project/core/sourcecontrol/Git.cs
+++ b/project/core/sourcecontrol/Git.cs
@@ -483,6 +483,7 @@ namespace ThoughtWorks.CruiseControl.Core.Sourcecontrol
             var processInfo = new ProcessInfo(Executable, args, BaseWorkingDirectory(result), priority,
                                                       successExitCodes);
             //processInfo.StreamEncoding = Encoding.UTF8;
+            processInfo.StandardInputContent = "";
             return processInfo;
         }
 


### PR DESCRIPTION
Workaround for Git for Windows 2.x
More specifically, "git submodule foreach" command, by setting `RedirectStandardInput` to `true`