### PR TITLE
[WebDashboard] The target "GatherAllFilesToPublish" does not exist in the project.

### DIFF
--- a/project/WebDashboard/WebDashboard.csproj
+++ b/project/WebDashboard/WebDashboard.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="15.0">
   <Import Project="..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\build\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props" Condition="Exists('..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.1\build\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
@@ -633,9 +633,6 @@
     <Content Include="..\xsl\msbuild.xsl">
       <Link>xsl\msbuild.xsl</Link>
     </Content>
-    <Content Include="..\xsl\MsTest2010Cover.xsl">
-      <Link>xsl\MsTest2010Cover.xsl</Link>
-    </Content>
     <Content Include="..\xsl\MsTestReport2010.xsl">
       <Link>xsl\MsTestReport2010.xsl</Link>
     </Content>
@@ -840,6 +837,7 @@
     <Content Include="Themes\noteWorthy\Manifest.xml" />
     <Content Include="Themes\Obsess\cruisecontrol.css" />
     <Content Include="Themes\Obsess\Manifest.xml" />
+    <Content Include="xsl\MsTestCover2010.xsl" />
     <Content Include="xsl\ndependreport-ccnet.v2.xsl" />
     <None Include="dashboard.config">
       <SubType>Designer</SubType>


### PR DESCRIPTION
Using visual studio 2013 update 5, I get the error message when publishing.
