### PR TITLE
add default credentials to urltrigger

### DIFF
--- a/project/core/util/HttpWrapper.cs
+++ b/project/core/util/HttpWrapper.cs
@@ -21,6 +21,7 @@ namespace ThoughtWorks.CruiseControl.Core.Util
 			HttpWebRequest request = (HttpWebRequest) WebRequest.Create(url);
 			request.ProtocolVersion = HttpVersion.Version11;
 			request.IfModifiedSince = previousModifiedTime;
+            request.Credentials = CredentialCache.DefaultCredentials;
 
 			try
 			{


### PR DESCRIPTION
Added the CredentialCache.DefaultCredentials to the request for the urltrigger.  This will pass through the user that the service is running as to the url for the trigger.