### PR TITLE
SourceControl/Mercurial: hg heads on a single branch (fix #281)

### DIFF
--- a/project/core/sourcecontrol/Mercurial/Mercurial.cs
+++ b/project/core/sourcecontrol/Mercurial/Mercurial.cs
@@ -530,6 +530,14 @@ namespace ThoughtWorks.CruiseControl.Core.Sourcecontrol.Mercurial
 		{
 			ProcessArgumentBuilder buffer = new ProcessArgumentBuilder();
 			buffer.AddArgument("heads");
+			if(string.IsNullOrEmpty(Branch))
+			{
+				buffer.AddArgument(".");
+			}
+			else
+			{
+				buffer.AddArgument(Branch);
+			}
 			buffer.AddArgument("--template", "{rev}:");
 
 			var bpi = GetBuildProgressInformation(result);


### PR DESCRIPTION
Fix [281](http://cruisecontrolnet.org/issues/281) on 1.8 branch.

If a `<branch>` has been set in the configuration, it's used on `hg heads` execution. Otherwise the current branch (`.`) is used.

This way you can have different branches in the repository but `<multipleHeadsFail>true</multipleHeadsFail>` will break the build only when the different heads are related to the selected branch.