### PR TITLE
Adding days in build time for long running tasks

### DIFF
--- a/project/UnitTests/Core/Publishers/Statistics/StatisticsBuilderTest.cs
+++ b/project/UnitTests/Core/Publishers/Statistics/StatisticsBuilderTest.cs
@@ -118,7 +118,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Publishers.Statistics
             results = builder.ProcessBuildResults(result);
 
             AssertHasStatistic("StartTime", DateUtil.FormatDate(result.StartTime), results);
-            AssertHasStatistic("Duration", new TimeSpan(0, 32, 0).ToString(), results);
+            AssertHasStatistic("Duration","00:00:32:00", results);
             //AssertHasStatistic("ProjectName", "Foo", results);
         }
 

--- a/project/UnitTests/Core/Publishers/XmlLogFixture.cs
+++ b/project/UnitTests/Core/Publishers/XmlLogFixture.cs
@@ -17,12 +17,12 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Publishers
 			string error = (result.Status == IntegrationStatus.Failure) ? " error=\"true\"" : String.Empty;
 			if (expectedBuildOutput == null)
 			{
-				return string.Format(@"<build date=""{0}"" buildtime=""00:00:00""{1} buildcondition=""{2}"" />", DateUtil.FormatDate(result.StartTime), error, result.BuildCondition);
+				return string.Format(@"<build date=""{0}"" buildtime=""00:00:00:00""{1} buildcondition=""{2}"" />", DateUtil.FormatDate(result.StartTime), error, result.BuildCondition);
 			}
 			else
 			{
 			    expectedBuildOutput = expectedBuildOutput.Replace("\r", string.Empty);
-				return string.Format(@"<build date=""{0}"" buildtime=""00:00:00""{1} buildcondition=""{3}"">{2}</build>", DateUtil.FormatDate(result.StartTime), error, expectedBuildOutput, result.BuildCondition);
+				return string.Format(@"<build date=""{0}"" buildtime=""00:00:00:00""{1} buildcondition=""{3}"">{2}</build>", DateUtil.FormatDate(result.StartTime), error, expectedBuildOutput, result.BuildCondition);
 			}
 		}
 	}

--- a/project/core/publishers/XmlIntegrationResultWriter.cs
+++ b/project/core/publishers/XmlIntegrationResultWriter.cs
@@ -96,7 +96,7 @@ namespace ThoughtWorks.CruiseControl.Core.Publishers
 
             // hide the milliseconds
             TimeSpan time = result.TotalIntegrationTime;
-            writer.WriteAttributeString("buildtime", string.Format(System.Globalization.CultureInfo.CurrentCulture,"{0:d2}:{1:d2}:{2:d2}", time.Hours, time.Minutes, time.Seconds));
+            writer.WriteAttributeString("buildtime", string.Format(System.Globalization.CultureInfo.CurrentCulture, "{0:d2}:{1:d2}:{2:d2}:{3:d2}", time.Days, time.Hours, time.Minutes, time.Seconds));
             if (result.Failed)
             {
                 writer.WriteAttributeString("error", "true");


### PR DESCRIPTION
Build time ("Running time on dashboard") is not showing days taken for the build.  This is a shortfall, when a build takes more than one day to finish.