### PR TITLE
git sourcecontrol add SparseCheckout support

### DIFF
--- a/build-package.bat
+++ b/build-package.bat
@@ -1,5 +1,5 @@
 @echo off
 cls
-Tools\NAnt\NAnt.exe package -buildfile:ccnet.build -D:CCNetLabel=1.5.0.0 -nologo -logfile:nant-build-package.log.txt %*
+Tools\NAnt\NAnt.exe package -buildfile:ccnet.build -D:CCNetLabel=1.8.5.0 -nologo -logfile:nant-build-package.log.txt %*
 echo %time% %date%
 pause

--- a/project/UnitTests/Core/SourceControl/GitTest.cs
+++ b/project/UnitTests/Core/SourceControl/GitTest.cs
@@ -121,6 +121,28 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol
             Assert.AreEqual(100, git.MaxAmountOfModificationsToFetch, "#C14");
 		}
 
+        [Test]
+        public void SparseCheckOutSpeclifedXML()
+        {
+            const string xml = @"
+<git>
+	<executable>git</executable>
+	<repository>git@git.gss.com.tw:HRSBU/HRSPD/Radar.Family/Radar2-Mtb.git</repository>
+	<branch>master</branch>
+	<workingDirectory>D:\git\working</workingDirectory>
+	<autoGetSource>true</autoGetSource>
+    <sparseCheckoutPaths><sparseCheckoutPath>MTB</sparseCheckoutPath></sparseCheckoutPaths>
+</git>";
+
+            git = (Git)NetReflector.Read(xml);
+            Assert.AreEqual("git", git.Executable, "#B1");
+            Assert.AreEqual(@"git@git.gss.com.tw:HRSBU/HRSPD/Radar.Family/Radar2-Mtb.git", git.Repository, "#B2");
+            Assert.AreEqual("master", git.Branch, "#B3");
+            Assert.AreEqual(@"D:\git\working", git.WorkingDirectory, "#B4");
+            Assert.AreEqual(true, git.AutoGetSource, "#B5");
+            Assert.AreEqual("MTB", git.SparseCheckoutPaths[0], "#B6");
+        }
+
 		[Test]
 		public void ShouldApplyLabelIfTagOnSuccessTrue()
 		{
@@ -265,7 +287,21 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol
 
 		private void ExpectToExecuteWithArgumentsAndReturn(string args, ProcessResult returnValue)
 		{
-			mockProcessExecutor.ExpectAndReturn("Execute", returnValue, NewProcessInfo(args, DefaultWorkingDirectory));
+			var processInfo = NewProcessInfo(args, DefaultWorkingDirectory);
+			processInfo.StandardInputContent = "";
+			mockProcessExecutor.ExpectAndReturn("Execute", returnValue, processInfo);
+		}
+
+		private new void ExpectToExecuteArguments(string args)
+		{
+			ExpectToExecuteArguments(args, DefaultWorkingDirectory);
+		}
+
+		protected new void ExpectToExecuteArguments(string args, string workingDirectory)
+		{
+			ProcessInfo processInfo = NewProcessInfo(args, workingDirectory);
+			processInfo.StandardInputContent = "";
+			ExpectToExecute(processInfo);
 		}
 
 		[Test]

--- a/project/core/sourcecontrol/Git.cs
+++ b/project/core/sourcecontrol/Git.cs
@@ -5,6 +5,7 @@ using ThoughtWorks.CruiseControl.Core.Util;
 using System.Globalization;
 using System.Collections.Generic;
 using ThoughtWorks.CruiseControl.Remote;
+using System;
 
 namespace ThoughtWorks.CruiseControl.Core.Sourcecontrol
 {
@@ -256,6 +257,14 @@ namespace ThoughtWorks.CruiseControl.Core.Sourcecontrol
         public string WorkingDirectory { get; set; }
 
         /// <summary>
+        /// use SparseCheckout to checkout path
+        /// </summary>
+        /// <version>1.8.5</version>
+        /// <default>sparse-checkout path</default>
+        [ReflectorProperty("sparseCheckoutPaths", Required = false)]
+        public string[] SparseCheckoutPaths { get; set; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="Git" /> class.	
         /// </summary>
         /// <remarks></remarks>
@@ -331,8 +340,8 @@ namespace ThoughtWorks.CruiseControl.Core.Sourcecontrol
             // checkout remote branch
             GitCheckoutRemoteBranch(Branch, result);
 
-			// update submodules
-			if (FetchSubmodules)
+            // update submodules
+            if (FetchSubmodules)
 				GitUpdateSubmodules(result);
 
             // clean up the local working copy
@@ -420,8 +429,28 @@ namespace ThoughtWorks.CruiseControl.Core.Sourcecontrol
             {
                 Log.Debug(string.Concat("[Git] Working directory '", workingDirectory, "' does not exist."));
 
-                // if the working does not exist, call git clone
-                GitClone(result);
+                // has SparseCheckout Path
+                if (SparseCheckoutPaths.Length > 0)
+                {
+                    _fileSystem.CreateDirectory(workingDirectory);
+
+                    //init git respository
+                    GitInit(result);
+
+                    //set sparseCheckout enable
+                    GitSetSparseCheckout(Branch, result);
+
+                    //set git remote url
+                    GitSetRometeUrl(Repository, result);
+
+                    //create sparse-checkout config
+                    CreateSparseCheckoutConfig(gitRepositoryDirectory, SparseCheckoutPaths, result);
+                }
+                else
+                {
+                    // if the working does not exist, call git clone
+                    GitClone(result);
+                }
 
                 // init submodules
                 if (FetchSubmodules)
@@ -483,6 +512,7 @@ namespace ThoughtWorks.CruiseControl.Core.Sourcecontrol
             var processInfo = new ProcessInfo(Executable, args, BaseWorkingDirectory(result), priority,
                                                       successExitCodes);
             //processInfo.StreamEncoding = Encoding.UTF8;
+            processInfo.StandardInputContent = "";
             return processInfo;
         }
 
@@ -629,6 +659,63 @@ namespace ThoughtWorks.CruiseControl.Core.Sourcecontrol
 
             // remove Stdout monitoring
             ProcessExecutor.ProcessOutput -= ProcessExecutor_ProcessOutput;
+        }
+
+        /// <summary>
+        /// git init
+        /// </summary>
+        /// <param name="result"></param>
+        private void GitInit(IIntegrationResult result)
+        {
+            ProcessArgumentBuilder buffer = new ProcessArgumentBuilder();
+            buffer.AddArgument("init");
+            Execute(NewProcessInfo(buffer.ToString(), result));
+        }
+
+        /// <summary>
+        /// Set SparseCheckout
+        /// </summary>
+        /// <param name="branchName"></param>
+        /// <param name="result"></param>
+        private void GitSetSparseCheckout(string branchName, IIntegrationResult result)
+        {
+            ProcessArgumentBuilder buffer = new ProcessArgumentBuilder();
+            buffer.AddArgument("config");
+            buffer.AddArgument("core.sparsecheckout");
+            buffer.AddArgument("true");
+            Execute(NewProcessInfo(buffer.ToString(), result));
+        }
+
+        /// <summary>
+        /// Set git Romete Url
+        /// </summary>
+        /// <param name="repository"></param>
+        /// <param name="result"></param>
+        private void GitSetRometeUrl(string repository, IIntegrationResult result)
+        {
+            ProcessArgumentBuilder buffer = new ProcessArgumentBuilder();
+            buffer.AddArgument("remote");
+            buffer.AddArgument("add");
+            buffer.AddArgument("-f");
+            buffer.AddArgument("origin");
+            buffer.AddArgument(repository);
+            Execute(NewProcessInfo(buffer.ToString(), result));
+        }
+
+        /// <summary>
+        /// Create SparseCheckout config file
+        /// </summary>
+        /// <param name="gitRepositoryDirectory"></param>
+        /// <param name="sparseCheckoutPaths"></param>
+        /// <param name="result"></param>
+        private void CreateSparseCheckoutConfig(string gitRepositoryDirectory, string[] sparseCheckoutPaths, IIntegrationResult result)
+        {
+            var configDir = string.Concat(gitRepositoryDirectory, @"\info\");
+            var configFile = string.Concat(configDir, "sparse-checkout");
+            if (Directory.Exists(configDir))
+            {
+                File.WriteAllLines(configFile, sparseCheckoutPaths);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
checkout git sourcecode can use sparse-checkout 

use sparseCheckoutPaths to setting sparse-checkout folder or file
        <!-- 從GIT取得Source Code -->
        <sourcecontrol type="git">
            <repository>$(ProjectGitUrl)</repository>
            <sparseCheckoutPaths>
                <sparseCheckoutPath>$(SourceFolder)/.nuget/*</sparseCheckoutPath>
                <sparseCheckoutPath>$(SourceFolder)/packages/*</sparseCheckoutPath>
                <sparseCheckoutPath>$(SourceFolder)/GetNuGet.cmd</sparseCheckoutPath>
                <sparseCheckoutPath>$(SourceFolder)/make.cmd</sparseCheckoutPath>
                <sparseCheckoutPath>$(SourceFolder)/WebService/*</sparseCheckoutPath>
                <sparseCheckoutPath>$(SourceFolder)/WebService.sln</sparseCheckoutPath>
            </sparseCheckoutPaths>
        </sourcecontrol>