### PR TITLE
Add https support to CCTray

### DIFF
--- a/project/CCTrayLib/Presentation/MainFormController.cs
+++ b/project/CCTrayLib/Presentation/MainFormController.cs
@@ -386,7 +386,16 @@ namespace ThoughtWorks.CruiseControl.CCTrayLib.Presentation
 		{
 			if (project.IsConnected)
 			{
-				string url = project.WebURL;
+
+			// replace plain http by https in case the buildserver is using https
+			string url = project.WebURL;
+			if(url != null && project.Configuration?.BuildServer?.Url != null 
+				&& project.Configuration.BuildServer.Url.StartsWith("https:") 
+				&& url.StartsWith("http:"))
+			{
+				url = url.Replace("http:", "https:");
+			}
+
 				Process.Start(url);
 			}
 		}

--- a/project/CommonAssemblyInfo.cs
+++ b/project/CommonAssemblyInfo.cs
@@ -14,7 +14,7 @@ using System.Reflection;
 [assembly: AssemblyProductAttribute("CruiseControl.NET")]
 [assembly: AssemblyCopyrightAttribute("Copyright © 2003 - 2014 ThoughtWorks Inc.")]
 [assembly: AssemblyTrademarkAttribute("")]
-[assembly: AssemblyVersionAttribute("0.0.0.0")]
-[assembly: AssemblyFileVersionAttribute("0.0.0.0")]
+[assembly: AssemblyVersionAttribute("1.8.5.1")]
+[assembly: AssemblyFileVersionAttribute("1.8.5.1")]
 [assembly: AssemblyInformationalVersionAttribute("Git hash : 0000000000000000000000000000000000000000")]
 

--- a/project/Remote/CruiseServerHttpClient.cs
+++ b/project/Remote/CruiseServerHttpClient.cs
@@ -206,6 +206,9 @@ namespace ThoughtWorks.CruiseControl.Remote
                 {
                     // Retrieve the XML from the server - 1.3 or later
                     var url = GenerateUrl("XmlServerReport.aspx");
+
+                    ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12 | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls | SecurityProtocolType.Ssl3;
+
                     webFunctions.SetCredentials(client, new Uri(url), false);
                     response = client.DownloadString(url);
                 }


### PR DESCRIPTION
This change adds security protocols to the CruiseServerHttpClient which allows the application to handle build servers that communicate over "https". (e.g. jenkins with cc.xml)
Since there is currently an issue with the jenkins cc.xml returning "http"-urls for build jobs while the server is running over "https", this change also contains a workaround to handle this issue by changing "http" to "https" in case the build server is using "https".

Also, the version for the application has been increased to 1.8.5.1 to distinguish the application for productive usage.