### PR TITLE
xcopy calls must be reserved for windows operating systems

### DIFF
--- a/Playground/CruiseControl.Core.Tests/CruiseControl.Core.Tests.csproj
+++ b/Playground/CruiseControl.Core.Tests/CruiseControl.Core.Tests.csproj
@@ -203,7 +203,8 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PreBuildEvent>xcopy /y/q "$(ProjectDir)..\..\tools\sleeper.exe" "$(TargetDir)"</PreBuildEvent>
+    <PreBuildEvent Condition=" '$(OS)' != 'Unix' >xcopy /y/q "$(ProjectDir)..\..\tools\sleeper.exe" "$(TargetDir)"</PreBuildEvent>
+    <PreBuildEvent Condition=" '$(OS)' == 'Unix' >cp -f "$(ProjectDir)..\..\tools\sleeper.exe" "$(TargetDir)"</PreBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/project/Core.Extensions/Core.Extensions.csproj
+++ b/project/Core.Extensions/Core.Extensions.csproj
@@ -91,9 +91,4 @@
       fi
     </PostBuildEvent>
   </PropertyGroup>
-  <PropertyGroup>
-    <PostBuildEvent>
-      if not "$(ConfigurationName)" == "Build" xcopy /Y "$(TargetPath)" "$(SolutionDir)console\bin\$(ConfigurationName)\"
-</PostBuildEvent>
-  </PropertyGroup>
 </Project>


### PR DESCRIPTION
There are quite a few calls to `xcopy` in pre/post build events and most are protected with an appropriate condition.
However, one has been missed and one has been added as a duplicate, most likely not voluntarily.
This pull request aims at fixing this