### PR TITLE
Linux unit tests compatibility

### DIFF
--- a/project/UnitTests/CCTrayLib/Presentation/AddProjectsTest.cs
+++ b/project/UnitTests/CCTrayLib/Presentation/AddProjectsTest.cs
@@ -19,6 +19,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.CCTrayLib.Presentation
 		}
 
 		[Test]
+        [Platform(Exclude = "Mono", Reason = "No X display available")]
 		public void TheServerListBoxIsPopulatedWithAListOfAllServersCurrentlyConfigured()
 		{
 			CCTrayProject[] projects = {
@@ -30,6 +31,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.CCTrayLib.Presentation
 		}
 
 		[Test]
+        [Platform(Exclude = "Mono", Reason = "No X display available")]
 		public void TheServerListBoxIsPopulatedInAlphabeticalOrder()
 		{
 			CCTrayProject[] projects = {
@@ -41,6 +43,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.CCTrayLib.Presentation
 		}
 
 		[Test]
+        [Platform(Exclude = "Mono", Reason = "No X display available")]
 		public void DuplicateServersAreIgnoredWhenAddingToTheServerList()
 		{
 			CCTrayProject[] projects = {
@@ -52,6 +55,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.CCTrayLib.Presentation
 		}
 
 		[Test]
+        [Platform(Exclude = "Mono", Reason = "No X display available")]
 		public void CurrentlyAddedProjectsAreIgnoredWhenServerIsSelected()
 		{
 			CCTrayProject[] allProjects = {

--- a/project/UnitTests/CCTrayLib/Presentation/CCTrayMultiSettingsFormTest.cs
+++ b/project/UnitTests/CCTrayLib/Presentation/CCTrayMultiSettingsFormTest.cs
@@ -10,6 +10,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.CCTrayLib.Presentation
 	public class CCTrayMultiSettingsFormTest
 	{
 		[Test]
+        [Platform(Exclude = "Mono", Reason = "No X display available")]
 		public void ShouldCloneConfigurationAndOnlyBindToTheClone()
 		{
 			var existingConfiguration = new Mock<ICCTrayMultiConfiguration>(MockBehavior.Strict);

--- a/project/UnitTests/CCTrayLib/Presentation/X10SettingsControlTest.cs
+++ b/project/UnitTests/CCTrayLib/Presentation/X10SettingsControlTest.cs
@@ -10,6 +10,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.CCTrayLib.Presentation
     public class X10SettingsControlTest
     {
         [Test]
+        [Platform(Exclude = "Mono", Reason = "No X display available")]
         public void CanBindToDefaultConfiguration()
         {
             X10SettingsControl control = new X10SettingsControl();

--- a/project/UnitTests/CCTrayLib/X10/X10ControllerTest.cs
+++ b/project/UnitTests/CCTrayLib/X10/X10ControllerTest.cs
@@ -50,6 +50,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.CCTrayLib.X10
 		}
 
 		[Test]
+        [Platform(Exclude = "Mono", Reason = "No X display available")]
 		public void SetsTheLightStatusCorrectlyBasedOnTheIntegrationStatus()
 		{
 			// for each set of conditions (Integration Status + Project State),
@@ -98,6 +99,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.CCTrayLib.X10
 		}
 		
 		[Test]
+        [Platform(Exclude = "Mono", Reason = "No X display available")]
 		public void WhenTheCurrentTimeIsOutsideTheAvailableHoursAllLightsAreSwitchedOff()
 		{
 			stubCurrentTimeProvider.SetNow(new DateTime(2005, 11, 05, 12, 00, 00));

--- a/project/UnitTests/CCnetDeploymentTests.cs
+++ b/project/UnitTests/CCnetDeploymentTests.cs
@@ -19,9 +19,9 @@ namespace ThoughtWorks.CruiseControl.UnitTests
         public void TestForAdminPackageOfWebDashboardIsEmpty()
         {
 #if DEBUG
-            string configFile = System.IO.Path.Combine(Directory.GetCurrentDirectory(), @"..\..\..\Webdashboard\dashboard.config");
+            string configFile = System.IO.Path.Combine(new string[] {Directory.GetCurrentDirectory(), "..", "..", "..", "WebDashboard", "dashboard.config"});
 #else
-            string configFile = System.IO.Path.Combine(Directory.GetCurrentDirectory(), @"..\..\Project\Webdashboard\dashboard.config");
+            string configFile = System.IO.Path.Combine(new string[] {Directory.GetCurrentDirectory(), "..", "..", "project", "WebDashboard", "dashboard.config"});
 #endif
             Assert.IsTrue(System.IO.File.Exists(configFile), "Dashboard.config not found at {0}", configFile);
 

--- a/project/UnitTests/Core/Config/PreprocessorTest.cs
+++ b/project/UnitTests/Core/Config/PreprocessorTest.cs
@@ -42,6 +42,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Config
         }
 
         [Test]
+        [Platform(Exclude = "Mono", Reason = "JScript not available")]
         public void TestBigFor()
         {
             XmlDocument doc = _Preprocess("TestBigFor.xml");
@@ -78,6 +79,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Config
         }
 
         [Test]
+        [Platform(Exclude = "Mono", Reason = "computername is unknown in mono, maybe fix the test file?")]
         public void TestEnvironmentVariableExpansion()
         {
             var doc = _Preprocess("TestEnvironmentVariableExpansion.xml");
@@ -89,6 +91,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Config
         }
 
         [Test]
+        [Platform(Exclude = "Mono", Reason = "JScript not available")]
         public void TestEvals()
         {
             XmlDocument doc = _Preprocess("TestEval.xml");
@@ -133,6 +136,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Config
         }
 
         [Test]
+        [Platform(Exclude = "Mono", Reason = "JScript not available")]
         public void TestFor()
         {
             XmlDocument doc = _Preprocess("TestFor.xml");
@@ -143,6 +147,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Config
         }
 
         [Test]
+        [Platform(Exclude = "Mono", Reason = "JScript not available")]
         public void TestForEach()
         {
             XmlDocument doc = _Preprocess("TestForEach.xml");
@@ -156,6 +161,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Config
         }
 
         [Test]
+        [Platform(Exclude = "Mono", Reason = "JScript not available")]
         public void TestIf()
         {
             XmlDocument doc = _Preprocess("TestIf.xml");
@@ -406,12 +412,14 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Config
         }
 
         [Test]
+        [Platform(Exclude = "Mono", Reason = "path is unknown")]
         public void TestSample()
         {            
             _Preprocess( "Sample.xml" );            
         }
 
         [Test]
+        [Platform(Exclude = "Mono", Reason = "computername is unknown")]
         public void TestSampleProject()
         {            
             _Preprocess( "SampleProject.xml" );

--- a/project/UnitTests/Core/Config/PreprocessorTest.cs
+++ b/project/UnitTests/Core/Config/PreprocessorTest.cs
@@ -13,7 +13,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Config
     [TestFixture]
     public class PreprocessorTest
     {
-    	private static readonly string FAKE_ROOT = Path.DirectorySeparatorChar == '\\' ? "c:\\temp folder\\" : "/tmp/";
+    	private static readonly string FAKE_ROOT = Platform.IsWindows ? "c:\\temp folder\\" : "/tmp/";
 
         private readonly XmlUrlResolver _resolver = new XmlUrlResolver();
 

--- a/project/UnitTests/Core/Config/PreprocessorTest.cs
+++ b/project/UnitTests/Core/Config/PreprocessorTest.cs
@@ -468,7 +468,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Config
 
                 Assert.AreEqual(env.Fileset.Length, 3);
                 Assert.AreEqual(GetTestPath("TestIncludeVariable.xml"), env.Fileset[0].LocalPath);
-                Assert.AreEqual(GetTestPath(@"Subfolder\TestIncluded.xml"), env.Fileset[1].LocalPath);
+                Assert.AreEqual(GetTestPath(String.Format( "Subfolder{0}TestIncluded.xml", Path.DirectorySeparatorChar )), env.Fileset[1].LocalPath);
                 Assert.AreEqual(GetTestPath("TestIncluded2.xml"), env.Fileset[2].LocalPath);
             }
         }

--- a/project/UnitTests/Core/Config/PreprocessorTest.cs
+++ b/project/UnitTests/Core/Config/PreprocessorTest.cs
@@ -558,7 +558,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Config
 			System.IO.Stream result = Assembly.GetExecutingAssembly().
 				GetManifestResourceStream(
 				"ThoughtWorks.CruiseControl.UnitTests.Core.Config.TestAssets." +
-				filename);
+				filename.Replace("/", "."));
             if (assertResourceFound)
             {
                 Assert.IsNotNull(result, "Unable to load data from assembly : " + filename);

--- a/project/UnitTests/Core/Config/ValidatingLoaderTest.cs
+++ b/project/UnitTests/Core/Config/ValidatingLoaderTest.cs
@@ -34,7 +34,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Config
 			tempfile = TempFileUtil.CreateTempFile("config", "project1.xml", @"<project name=""p1"" />");
 			string xml = 
 @"<!DOCTYPE cruisecontrol [ 
-	<!ENTITY project1 SYSTEM ""file:" + tempfile + @""">
+	<!ENTITY project1 SYSTEM ""file://" + tempfile + @""">
 ]> 
 <cruisecontrol>&project1;</cruisecontrol>";
 			XmlTextReader xr = new XmlTextReader(new StringReader(xml));

--- a/project/UnitTests/Core/Config/ValidatingLoaderTest.cs
+++ b/project/UnitTests/Core/Config/ValidatingLoaderTest.cs
@@ -42,7 +42,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Config
 			XmlDocument doc = loader.Load();
 			Assert.IsNotNull(doc, "Unable to load document because it is not valid according to reader");
 			IConfiguration config = new NetReflectorConfigurationReader().Read(doc, null);
-			Assert.IsNotNull(config.Projects["p1"]);
+			Assert.IsNotNull(config.Projects["p1"], "p1 should have been found");
 		}
 
 		[TearDown]

--- a/project/UnitTests/Core/IntegrationResultManagerTest.cs
+++ b/project/UnitTests/Core/IntegrationResultManagerTest.cs
@@ -35,7 +35,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core
 
 			IIntegrationResult result = manager.StartNewIntegration(ForceBuildRequest());
 			Assert.AreEqual("project", result.ProjectName);
-			Assert.AreEqual(@"c:\temp", result.WorkingDirectory);
+			Assert.AreEqual(Platform.IsWindows ? @"c:\temp" : @"/tmp", result.WorkingDirectory);
 			Assert.AreEqual(BuildCondition.ForceBuild, result.BuildCondition);
 			Assert.AreEqual("success", result.Label);
 			Assert.AreEqual(project.ArtifactDirectory, result.ArtifactDirectory);
@@ -178,7 +178,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core
 		{	
 			project = new Project();
 			project.Name = "project";
-			project.ConfiguredWorkingDirectory = @"c:\temp";
+			project.ConfiguredWorkingDirectory = Platform.IsWindows ? @"c:\temp" : @"/tmp";
 			project.StateManager = (IStateManager) mockStateManager.Object;
 			project.ConfiguredArtifactDirectory = project.ConfiguredWorkingDirectory;            
 			return project;

--- a/project/UnitTests/Core/Log/ServerLogFileReaderTest.cs
+++ b/project/UnitTests/Core/Log/ServerLogFileReaderTest.cs
@@ -147,10 +147,8 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Logging
 			SystemPath tempFile = tempDir.CreateTextFile("MultiProject.log", content);
 			
 			ServerLogFileReader reader = new ServerLogFileReader(tempFile.ToString(), 10);
-			Assert.AreEqual(@"2006-11-24 20:09:53,000 [foo:INFO] Starting integrator for project: foo
-2006-11-24 20:09:55,000 [foo:INFO] No modifications detected", reader.Read("foo"));
-			Assert.AreEqual(@"2006-11-24 20:09:54,000 [bar:INFO] Starting integrator for project: bar
-2006-11-24 20:09:56,000 [bar:INFO] No modifications detected.", reader.Read("bar"));
+			Assert.AreEqual(@"2006-11-24 20:09:53,000 [foo:INFO] Starting integrator for project: foo" + Environment.NewLine + "2006-11-24 20:09:55,000 [foo:INFO] No modifications detected", reader.Read("foo"));
+			Assert.AreEqual(@"2006-11-24 20:09:54,000 [bar:INFO] Starting integrator for project: bar" + Environment.NewLine + "2006-11-24 20:09:56,000 [bar:INFO] No modifications detected.", reader.Read("bar"));
 		}
 		
 		private static string[] GenerateContentLines(int lines)
@@ -171,7 +169,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Logging
 
 		private static string[] StringToLines(string content)
 		{
-			Regex regexLines = new Regex(@"\r\n");
+			Regex regexLines = new Regex(Environment.NewLine);
 			return regexLines.Split(content);
 		}
 	}

--- a/project/UnitTests/Core/LogFileTest.cs
+++ b/project/UnitTests/Core/LogFileTest.cs
@@ -69,6 +69,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core
 			{
 				CreateTempFiles(tempPath, testFilenames);
 				string[] fileNames = LogFileUtil.GetLogFileNames(tempPath.ToString());
+                Array.Sort(fileNames);
 				Assert.AreEqual(3,fileNames.Length);
 				Assert.AreEqual(testFilenames[0],fileNames[0]);
 				Assert.AreEqual(testFilenames[1],fileNames[1]);

--- a/project/UnitTests/Core/ProjectTest.cs
+++ b/project/UnitTests/Core/ProjectTest.cs
@@ -357,7 +357,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core
 			mockSourceControl.Setup(sourceControl => sourceControl.LabelSourceControl(It.IsAny<IIntegrationResult>())).Verifiable();
 			mockPublisher.Setup(publisher => publisher.Run(It.IsAny<IIntegrationResult>())).Verifiable();
 			mockTask.Setup(task => task.Run(It.IsAny<IntegrationResult>())).Callback<IIntegrationResult>(r => r.AddTaskResult("success")).Verifiable();
-			project.ConfiguredWorkingDirectory = @"c:\temp";
+			project.ConfiguredWorkingDirectory = Platform.IsWindows ? @"c:\temp" : @"/tmp";
 
 			IIntegrationResult result = project.Integrate(ModificationExistRequest());
 
@@ -367,7 +367,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core
 			Assert.AreEqual(IntegrationStatus.Success, result.Status);
 			Assert.AreEqual(IntegrationStatus.Unknown, result.LastIntegrationStatus);
 			Assert.AreEqual(BuildCondition.ForceBuild, result.BuildCondition);
-			Assert.AreEqual(@"c:\temp", result.WorkingDirectory);
+			Assert.AreEqual(Platform.IsWindows ? @"c:\temp" : @"/tmp", result.WorkingDirectory);
 			Assert.AreEqual(result, project.CurrentResult);
 			Assert.AreEqual("label", result.Label);
 			AssertFalse("unexpected modifications were returned", result.HasModifications());

--- a/project/UnitTests/Core/Publishers/EmailPublisherTest.cs
+++ b/project/UnitTests/Core/Publishers/EmailPublisherTest.cs
@@ -272,10 +272,10 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Publishers
 		{
 			publisher.IncludeDetails = true;
 			string message = publisher.CreateMessage(CreateIntegrationResult(IntegrationStatus.Success, IntegrationStatus.Success));
-			Assert.IsTrue(message.StartsWith("<html>"));
-			Assert.IsTrue(message.IndexOf("CruiseControl.NET Build Results for project Project#9") > 0);
-			Assert.IsTrue(message.IndexOf("Modifications since last build") > 0);
-			Assert.IsTrue(message.EndsWith("</html>"));
+			Assert.IsTrue(message.StartsWith("<html>"), "message does not start with html: " + message);
+			Assert.IsTrue(message.IndexOf("CruiseControl.NET Build Results for project Project#9") > 0, "message does not contain header: " + message);
+			Assert.IsTrue(message.IndexOf("Modifications since last build") > 0, "message does not contain modifications: " + message);
+			Assert.IsTrue(message.EndsWith("</html>"), "message does not end with html: " + message);
 		}
 
 		[Test]
@@ -311,7 +311,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Publishers
 			publisher.IncludeDetails = true;
 
 			string message = publisher.CreateMessage(result);
-			Assert.IsTrue(message.IndexOf("Tests run") >= 0);
+			Assert.IsTrue(message.IndexOf("Tests run") >= 0, "message does not contain 'Tests run': " + message);
 		}
 
         [Test]
@@ -449,9 +449,9 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Publishers
 
 			publisher.IncludeDetails = true;
 			string actual = publisher.CreateMessage(result);
-			Assert.IsTrue(actual.IndexOf(result.ExceptionResult.Message) > 0);
-			Assert.IsTrue(actual.IndexOf(result.ExceptionResult.GetType().Name) > 0);
-			Assert.IsTrue(actual.IndexOf("BUILD COMPLETE") == -1); // verify build complete message is not output
+			Assert.IsTrue(actual.IndexOf(result.ExceptionResult.Message) > 0, "message does not contain exception result message: " + actual);
+			Assert.IsTrue(actual.IndexOf(result.ExceptionResult.GetType().Name) > 0, "message does not contain exception result type name: " + actual);
+			Assert.IsTrue(actual.IndexOf("BUILD COMPLETE") == -1, "message does not contain 'BUILD COMPLETE': " + actual); // verify build complete message is not output
 		}
 	}
 }

--- a/project/UnitTests/Core/Publishers/EmailUserTest.cs
+++ b/project/UnitTests/Core/Publishers/EmailUserTest.cs
@@ -1,3 +1,4 @@
+using System;
 using Exortech.NetReflector;
 using NUnit.Framework;
 using ThoughtWorks.CruiseControl.Core.Publishers;
@@ -19,7 +20,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Publishers
         {
             Assert.That(delegate { NetReflector.Read(@"<user address=""UserName@example.com""/>"); },
                         Throws.TypeOf<NetReflectorException>().With.Message.EqualTo(
-                            "Missing Xml node (name) for required member (ThoughtWorks.CruiseControl.Core.Publishers.EmailUser.Name).\r\nXml: <user address=\"UserName@example.com\" />"));
+                            "Missing Xml node (name) for required member (ThoughtWorks.CruiseControl.Core.Publishers.EmailUser.Name)." + Environment.NewLine + "Xml: <user address=\"UserName@example.com\" />"));
         }
 
         [Test]

--- a/project/UnitTests/Core/Publishers/ModificationHistoryPublisherTest.cs
+++ b/project/UnitTests/Core/Publishers/ModificationHistoryPublisherTest.cs
@@ -46,7 +46,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Publishers
             IntegrationResult result = CreateIntegrationResult(IntegrationStatus.Success, false);
             result.ArtifactDirectory = ARTIFACTS_DIR_PATH;
             string PublishedModifications;
-            string ExpectedLoggedModifications = string.Format(System.Globalization.CultureInfo.CurrentCulture,"<History><Build BuildDate=\"{0}\" Success=\"True\" Label=\"{1}\" />\r\n</History>",
+            string ExpectedLoggedModifications = string.Format(System.Globalization.CultureInfo.CurrentCulture,"<History><Build BuildDate=\"{0}\" Success=\"True\" Label=\"{1}\" />" + Environment.NewLine + "</History>",
                                                     DateUtil.FormatDate(result.StartTime), result.Label);
 
             // Execute

--- a/project/UnitTests/Core/Publishers/PackageFileTests.cs
+++ b/project/UnitTests/Core/Publishers/PackageFileTests.cs
@@ -23,7 +23,7 @@
         [Test]
         public void HandlesShortDirectoryName()
         {
-            var testFile = @"C:\Somewhere.txt";
+            var testFile = Platform.IsWindows ? @"C:\Somewhere.txt" : @"/Somewhere.txt";
             var result = mocks.Create<IIntegrationResult>(MockBehavior.Strict).Object;
             Mock.Get(result).SetupGet(_result => _result.WorkingDirectory).Returns(@"C:\OnceUponATime\InALandFarFarWayFromHere\ThereLivedABeautifulPrincess");
             var fileSystem = mocks.Create<IFileSystem>(MockBehavior.Strict).Object;

--- a/project/UnitTests/Core/Publishers/Statistics/StatisticsBuilderWithNamespacesTest.cs
+++ b/project/UnitTests/Core/Publishers/Statistics/StatisticsBuilderWithNamespacesTest.cs
@@ -18,7 +18,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Publishers.Statistics
         public void ShowOutputOfStatisticsInConsole()
         {
             StringBuilder buffer = new StringBuilder();
-            System.IO.StreamReader reader = System.IO.File.OpenText(@"resources\UnitTestResults2.xml");
+            System.IO.StreamReader reader = System.IO.File.OpenText(System.IO.Path.Combine(@"resources", @"UnitTestResults2.xml"));
             var buildlog= reader.ReadToEnd();
             reader.Close();
 

--- a/project/UnitTests/Core/SourceControl/AlienbrainTest.cs
+++ b/project/UnitTests/Core/SourceControl/AlienbrainTest.cs
@@ -194,7 +194,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol
 			registry.Setup(r => r.GetExpectedLocalMachineSubKeyValue(Alienbrain.AB_REGISTRY_PATH, Alienbrain.AB_REGISTRY_KEY)).Returns(INSTALLDIR).Verifiable();
 			alienbrain.Executable = string.Empty;
 
-			Assert.AreEqual(INSTALLDIR + "\\" + Alienbrain.AB_COMMMAND_PATH + "\\" + Alienbrain.AB_EXE, alienbrain.Executable);
+			Assert.AreEqual(INSTALLDIR + System.IO.Path.DirectorySeparatorChar + Alienbrain.AB_COMMMAND_PATH + "\\" + Alienbrain.AB_EXE, alienbrain.Executable);
 			Assert.AreEqual(SERVER, alienbrain.Server);
 			Assert.AreEqual(DATABASE, alienbrain.Database);
 			Assert.AreEqual(USER, alienbrain.Username);

--- a/project/UnitTests/Core/SourceControl/ClearCaseHistoryParserTest.cs
+++ b/project/UnitTests/Core/SourceControl/ClearCaseHistoryParserTest.cs
@@ -10,6 +10,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol
 	public class ClearCaseHistoryParserTest 
 	{
 		ClearCaseHistoryParser parser;
+        string path = Platform.IsWindows ? @"D:\CCase\ppunjani_view\RefArch\tutorial\wwhdata\common" : @"/CCase/ppunjani_view/RefArch/tutorial/wwhdata/common";
 
 		[SetUp]
 		protected void Setup()
@@ -20,11 +21,11 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol
 		[Test]
 		public void CanTokenizeWithNoComment()
 		{
-			string[] tokens = parser.TokenizeEntry( @"ppunjani#~#Friday, September 27, 2002 06:31:36 PM#~#D:\CCase\ppunjani_view\RefArch\tutorial\wwhdata\common\context.js#~#\main\0#~#mkelem#~#!#~#!#~#" );
+			string[] tokens = parser.TokenizeEntry( @"ppunjani#~#Friday, September 27, 2002 06:31:36 PM#~#" + System.IO.Path.Combine(path, "context.js") + @"#~#\main\0#~#mkelem#~#!#~#!#~#" );
 			Assert.AreEqual( 8, tokens.Length );
 			Assert.AreEqual( "ppunjani", tokens[ 0 ] );
 			Assert.AreEqual( "Friday, September 27, 2002 06:31:36 PM", tokens[ 1 ] );
-			Assert.AreEqual( @"D:\CCase\ppunjani_view\RefArch\tutorial\wwhdata\common\context.js", tokens[ 2 ] );
+			Assert.AreEqual( System.IO.Path.Combine(path, "context.js"), tokens[ 2 ] );
 			Assert.AreEqual( @"\main\0", tokens[ 3 ] );
 			Assert.AreEqual("mkelem", tokens[ 4 ] );
 			Assert.AreEqual( "!", tokens[ 5 ] );
@@ -38,9 +39,8 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol
 			const string userName = "gsmith";
 			const string timeStamp = "Wednesday, March 10, 2004 08:52:05 AM";
 			DateTime expectedTime = new DateTime( 2004, 03, 10, 08, 52, 05 );
-			const string path = @"D:\CCase\ppunjani_view\RefArch\tutorial\wwhdata\common";
 			const string file = "context.js";
-			const string elementName = path + "\\" + file;
+			string elementName = System.IO.Path.Combine(path, file);
 			const string modificationType = "checkin";
 			const string comment = "implemented dwim";
 			const string change = @"\main\17";
@@ -65,15 +65,14 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol
 		[Test]
 		public void CanAssignFileInfo()
 		{
-			const string path = @"D:\CCase\ppunjani_view\RefArch\tutorial\wwhdata\common";
 			const string file = "context.js";
-			const string fullPath = path + "\\" + file;
+			string fullPath = System.IO.Path.Combine(path, file);
 			Modification modification = new Modification();
 
 			parser.AssignFileInfo( modification, fullPath );
 
-			Assert.AreEqual( path, modification.FolderName );
-			Assert.AreEqual( file, modification.FileName );
+			Assert.AreEqual( path, modification.FolderName, "FolderName" );
+			Assert.AreEqual( file, modification.FileName, "FileName" );
 		}
 
 		
@@ -114,21 +113,21 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol
 		[Test]
 		public void IgnoresMkBranchEvent()
 		{
-			Modification modification = parser.ParseEntry( @"ppunjani#~#Friday, September 27, 2002 06:31:36 PM#~#D:\CCase\ppunjani_view\RefArch\tutorial\wwhdata\common\context.js#~#\main\0#~#mkbranch#~#!#~#!#~#" );
+			Modification modification = parser.ParseEntry( @"ppunjani#~#Friday, September 27, 2002 06:31:36 PM#~#" + System.IO.Path.Combine(path, "context.js") + @"#~#\main\0#~#mkbranch#~#!#~#!#~#" );
 			Assert.IsNull( modification );
 		}
 
 		[Test]
 		public void IgnoresRmBranchEvent()
 		{
-			Modification modification = parser.ParseEntry( @"ppunjani#~#Friday, September 27, 2002 06:31:36 PM#~#D:\CCase\ppunjani_view\RefArch\tutorial\wwhdata\common\context.js#~#\main\0#~#rmbranch#~#!#~#!#~#" );
+			Modification modification = parser.ParseEntry( @"ppunjani#~#Friday, September 27, 2002 06:31:36 PM#~#" + System.IO.Path.Combine(path, "context.js") + @"#~#\main\0#~#rmbranch#~#!#~#!#~#" );
 			Assert.IsNull( modification );
 		}
 
 		[Test]
 		public void CanParseBadEntry()
 		{
-			Modification modification = parser.ParseEntry( @"ppunjani#~#Tuesday, February 18, 2003 05:09:14 PM#~#D:\CCase\ppunjani_view\RefArch\tutorial\wwhdata\common\wwhpagef.js#~#\main\0#~#mkbranch#~#!#~#!#~#" );
+			Modification modification = parser.ParseEntry( @"ppunjani#~#Tuesday, February 18, 2003 05:09:14 PM#~#" + System.IO.Path.Combine(path, "wwhpagef.js") + @"#~#\main\0#~#mkbranch#~#!#~#!#~#" );
 			Assert.IsNull( modification );
 		}
 
@@ -143,10 +142,10 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol
 		[Test]
 		public void CanParseEntry()
 		{
-			Modification modification = parser.ParseEntry( @"ppunjani#~#Wednesday, November 20, 2002 07:37:22 PM#~#D:\CCase\ppunjani_view\RefArch\tutorial\wwhdata\common\towwhdir.js#~#\main#~#mkelem#~#!#~#!#~#" );
+			Modification modification = parser.ParseEntry( @"ppunjani#~#Wednesday, November 20, 2002 07:37:22 PM#~#" + System.IO.Path.Combine(path, "towwhdir.js") + @"#~#\main#~#mkelem#~#!#~#!#~#" );
 			Assert.AreEqual( "ppunjani", modification.UserName );
 			Assert.AreEqual( new DateTime( 2002, 11, 20, 19, 37, 22), modification.ModifiedTime );
-			Assert.AreEqual( @"D:\CCase\ppunjani_view\RefArch\tutorial\wwhdata\common", modification.FolderName );
+			Assert.AreEqual( path, modification.FolderName );
 			Assert.AreEqual( "towwhdir.js", modification.FileName );
 			Assert.AreEqual( "mkelem", modification.Type );
 			Assert.AreEqual( "!", modification.ChangeNumber );
@@ -156,10 +155,10 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol
 		[Test]
 		public void CanParseEntryWithNoComment()
 		{
-			Modification modification = parser.ParseEntry( @"ppunjani#~#Wednesday, February 25, 2004 01:09:36 PM#~#D:\CCase\ppunjani_view\RefArch\tutorial\wwhdata\common\topics.js#~##~#**null operation kind**#~#!#~#!#~#" );
+			Modification modification = parser.ParseEntry( @"ppunjani#~#Wednesday, February 25, 2004 01:09:36 PM#~#" + System.IO.Path.Combine(path, "topics.js") + @"#~##~#**null operation kind**#~#!#~#!#~#" );
 			Assert.AreEqual( "ppunjani", modification.UserName);
 			Assert.AreEqual( new DateTime( 2004, 02, 25, 13, 09, 36 ), modification.ModifiedTime);
-			Assert.AreEqual( @"D:\CCase\ppunjani_view\RefArch\tutorial\wwhdata\common", modification.FolderName);
+			Assert.AreEqual( path, modification.FolderName);
 			Assert.AreEqual( "topics.js", modification.FileName);
 			Assert.AreEqual( "**null operation kind**", modification.Type );
 			Assert.AreEqual( "!", modification.ChangeNumber );
@@ -169,11 +168,11 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol
 		[Test]
 		public void CanTokenize()
 		{
-			string[] tokens = parser.TokenizeEntry( @"ppunjani#~#Friday, March 21, 2003 03:32:24 PM#~#D:\CCase\ppunjani_view\RefArch\tutorial\wwhdata\common\files.js#~##~#mkelem#~#!#~#!#~#made from flat file" );
+			string[] tokens = parser.TokenizeEntry( @"ppunjani#~#Friday, March 21, 2003 03:32:24 PM#~#" + System.IO.Path.Combine(path, "files.js") + @"#~##~#mkelem#~#!#~#!#~#made from flat file" );
 			Assert.AreEqual( 8, tokens.Length );
 			Assert.AreEqual( "ppunjani", tokens[0] );
 			Assert.AreEqual( "Friday, March 21, 2003 03:32:24 PM", tokens[1] );
-			Assert.AreEqual( @"D:\CCase\ppunjani_view\RefArch\tutorial\wwhdata\common\files.js", tokens[2] );
+			Assert.AreEqual( System.IO.Path.Combine(path, "files.js"), tokens[2] );
 			Assert.AreEqual( string.Empty, tokens[3] );
 			Assert.AreEqual( "mkelem", tokens[4] );
 			Assert.AreEqual( "!", tokens[5] );
@@ -184,10 +183,10 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol
 		[Test]
 		public void CanParseEntryWithNoLineBreakInComment()
 		{
-			Modification modification = parser.ParseEntry( @"ppunjani#~#Wednesday, November 20, 2002 07:37:22 PM#~#D:\CCase\ppunjani_view\RefArch\tutorial\wwhdata\common\towwhdir.js#~#\main#~#mkelem#~#!#~#!#~#simple comment" );
+			Modification modification = parser.ParseEntry( @"ppunjani#~#Wednesday, November 20, 2002 07:37:22 PM#~#" + System.IO.Path.Combine(path, "towwhdir.js") + @"#~#\main#~#mkelem#~#!#~#!#~#simple comment" );
 			Assert.AreEqual( "ppunjani", modification.UserName );
 			Assert.AreEqual( new DateTime( 2002, 11, 20, 19, 37, 22), modification.ModifiedTime );
-			Assert.AreEqual( @"D:\CCase\ppunjani_view\RefArch\tutorial\wwhdata\common", modification.FolderName );
+			Assert.AreEqual( path, modification.FolderName );
 			Assert.AreEqual( "towwhdir.js", modification.FileName );
 			Assert.AreEqual( "mkelem", modification.Type );
 			Assert.AreEqual( "!", modification.ChangeNumber );
@@ -197,12 +196,12 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol
 		[Test]
 		public void CanParseStreamWithNoLineBreakInComment()
 		{
-			string input = @"ppunjani#~#Wednesday, November 20, 2002 07:37:22 PM#~#D:\CCase\ppunjani_view\RefArch\tutorial\wwhdata\common\towwhdir.js#~#\main#~#mkelem#~#!#~#!#~#simple comment@#@#@#@#@#@#@#@#@#@#@#@";
+			string input = @"ppunjani#~#Wednesday, November 20, 2002 07:37:22 PM#~#" + System.IO.Path.Combine(path, "towwhdir.js") + @"#~#\main#~#mkelem#~#!#~#!#~#simple comment@#@#@#@#@#@#@#@#@#@#@#@";
 
 			Modification modification = parser.Parse(new StringReader(input), DateTime.Now, DateTime.Now)[0];
 			Assert.AreEqual( "ppunjani", modification.UserName );
 			Assert.AreEqual( new DateTime( 2002, 11, 20, 19, 37, 22), modification.ModifiedTime );
-			Assert.AreEqual( @"D:\CCase\ppunjani_view\RefArch\tutorial\wwhdata\common", modification.FolderName );
+			Assert.AreEqual( path, modification.FolderName );
 			Assert.AreEqual( "towwhdir.js", modification.FileName );
 			Assert.AreEqual( "mkelem", modification.Type );
 			Assert.AreEqual( "!", modification.ChangeNumber );
@@ -212,13 +211,13 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol
 		[Test]
 		public void CanParseStreamWithLineBreakInComment()
 		{
-			string input = @"ppunjani#~#Wednesday, November 20, 2002 07:37:22 PM#~#D:\CCase\ppunjani_view\RefArch\tutorial\wwhdata\common\towwhdir.js#~#\main#~#mkelem#~#!#~#!#~#simple comment 
+			string input = @"ppunjani#~#Wednesday, November 20, 2002 07:37:22 PM#~#" + System.IO.Path.Combine(path, "towwhdir.js") + @"#~#\main#~#mkelem#~#!#~#!#~#simple comment 
 with linebreak@#@#@#@#@#@#@#@#@#@#@#@";
 
 			Modification modification = parser.Parse(new StringReader(input), DateTime.Now, DateTime.Now)[0];
 			Assert.AreEqual( "ppunjani", modification.UserName );
 			Assert.AreEqual( new DateTime( 2002, 11, 20, 19, 37, 22), modification.ModifiedTime );
-			Assert.AreEqual( @"D:\CCase\ppunjani_view\RefArch\tutorial\wwhdata\common", modification.FolderName );
+			Assert.AreEqual( path, modification.FolderName );
 			Assert.AreEqual( "towwhdir.js", modification.FileName );
 			Assert.AreEqual( "mkelem", modification.Type );
 			Assert.AreEqual( "!", modification.ChangeNumber );

--- a/project/UnitTests/Core/SourceControl/FileSourceControlTest.cs
+++ b/project/UnitTests/Core/SourceControl/FileSourceControlTest.cs
@@ -70,24 +70,35 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol
 			string file3 = tempSubRoot.CreateTextFile("file3.txt", "bat").ToString();
 
 			Modification[] mods = sc.GetModifications(IntegrationResult(DateTime.MinValue), IntegrationResult(DateTime.MaxValue));
+            Array.Sort(
+                mods,
+                (left, right) => 
+                {
+                    int result = left.FolderName.CompareTo(right.FolderName);
+                    if (result == 0) 
+                        result = left.FileName.CompareTo(right.FileName);
+                        
+                    return result;
+                }
+            );
 
 			using( new AssertionScope())
 			{
 				mods.Length.Should().Be(4);
-				mods[0].FileName.Should().Be("file1.txt");
-				mods[1].FileName.Should().Be("file2.txt");
-				mods[2].FileName.Should().Be(Path.GetFileName(tempSubRoot.ToString()));
-				mods[3].FileName.Should().Be("file3.txt");
+				mods[0].FileName.Should().Be("file1.txt", "FileName[0]");
+				mods[1].FileName.Should().Be("file2.txt", "FileName[1]");
+				mods[2].FileName.Should().Be("file3.txt", "FileName[2]");
+				mods[3].FileName.Should().Be(Path.GetFileName(tempSubRoot.ToString()), "FileName[3]");
 
-				mods[0].FolderName.Should().Be(Path.GetDirectoryName(file1));
-				mods[1].FolderName.Should().Be(Path.GetDirectoryName(file2));
-				mods[2].FolderName.Should().Be(Path.GetFileName(tempSubRoot.ToString()));
-				mods[3].FolderName.Should().Be(Path.GetDirectoryName(file3));
+				mods[0].FolderName.Should().Be(Path.GetDirectoryName(file1), "FolderName[0]");
+				mods[1].FolderName.Should().Be(Path.GetDirectoryName(file2), "FolderName[1]");
+				mods[2].FolderName.Should().Be(Path.GetDirectoryName(file3), "FolderName[2]");
+				mods[3].FolderName.Should().Be(Path.GetFileName(tempSubRoot.ToString()), "FolderName[3]");
 
-				new FileInfo(file1).LastWriteTime.Should().BeCloseTo(mods[0].ModifiedTime,  100);
-				new FileInfo(file2).LastWriteTime.Should().BeCloseTo(mods[1].ModifiedTime, 100);
-				new FileInfo(tempSubRoot.ToString()).LastWriteTime.Should().BeCloseTo(mods[2].ModifiedTime, 100);
-				new FileInfo(file3).LastWriteTime.Should().BeCloseTo(mods[3].ModifiedTime, 100);
+				new FileInfo(file1).LastWriteTime.Should().BeCloseTo(mods[0].ModifiedTime,  100, "LastWriteTime[0]");
+				new FileInfo(file2).LastWriteTime.Should().BeCloseTo(mods[1].ModifiedTime, 100, "LastWriteTime[1]");
+				new FileInfo(file3).LastWriteTime.Should().BeCloseTo(mods[2].ModifiedTime, 100, "LastWriteTime[2]");
+				new FileInfo(tempSubRoot.ToString()).LastWriteTime.Should().BeCloseTo(mods[3].ModifiedTime, 100, "LastWriteTime[3]");
 			}
 
             mods = sc.GetModifications(IntegrationResult(DateTime.Now.AddHours(1)), IntegrationResult(DateTime.MaxValue));
@@ -157,6 +168,10 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol
             sc.CheckRecursively = false;
 
             Modification[] mods = sc.GetModifications(IntegrationResult(DateTime.MinValue), IntegrationResult(DateTime.MaxValue));
+            Array.Sort(
+                mods,
+                (left, right) => left.FileName.CompareTo(right.FileName)
+            );
 
 			using(new AssertionScope())
 			{

--- a/project/UnitTests/Core/SourceControl/GitHistoryParserTest.cs
+++ b/project/UnitTests/Core/SourceControl/GitHistoryParserTest.cs
@@ -153,7 +153,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol
 
 			var mod = modifications[0];
 			var combinedPath = Path.Combine(mod.FolderName, mod.FileName);
-			Assert.That(combinedPath, Is.EqualTo("/site/assets/pdfs\\BWMF Politique de gestion des conflits d'int\\303\\203\\302\\251r\\303\\203\\302\\252ts.pdf"));
+			Assert.That(combinedPath, Is.EqualTo(Path.Combine("/site/assets/pdfs", "BWMF Politique de gestion des conflits d'int\\303\\203\\302\\251r\\303\\203\\302\\252ts.pdf")));
 		}
 	}
 }

--- a/project/UnitTests/Core/SourceControl/Mercurial/MercurialHistoryParserTest.cs
+++ b/project/UnitTests/Core/SourceControl/Mercurial/MercurialHistoryParserTest.cs
@@ -143,7 +143,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol.Mercurial
 			Assert.That(modifications.Length, Is.EqualTo(1));
 
 			var mod = modifications[0];
-			Assert.That(mod.FolderName, Is.EqualTo(@"these\are\the\parent\folders\to\this"));
+			Assert.That(mod.FolderName, Is.EqualTo(System.IO.Path.Combine(new string[] {"these", "are", "the", "parent", "folders", "to", "this"})));
 			Assert.That(mod.FileName, Is.EqualTo("file.txt"));
 		}
 

--- a/project/UnitTests/Core/SourceControl/MksHistoryParserTest.cs
+++ b/project/UnitTests/Core/SourceControl/MksHistoryParserTest.cs
@@ -13,6 +13,8 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol
 	{
 	    private string TEST_DATA = String.Empty;
         private string MEMBER_INFO = String.Empty;
+        private static string windowsPath = @"c:\Sandboxes\Personal2";
+        private string path = Platform.IsWindows ? windowsPath : @"/Sandboxes/Personal2";
 
         [OneTimeSetUp]
         public void SetUp()
@@ -29,7 +31,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol
                     if (s != null)
                     {
                         StreamReader rdr = new StreamReader(s);
-                        TEST_DATA = rdr.ReadToEnd();
+                        TEST_DATA = rdr.ReadToEnd().Replace(windowsPath.Replace('\\', '/'), path);
                     }
                     else
                     {
@@ -72,7 +74,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol
 		        {
 		            changeCount++;
                     Assert.AreEqual("TestFile1.txt", modification.FileName);
-                    Assert.AreEqual(@"c:\Sandboxes\Personal2", modification.FolderName);
+                    Assert.AreEqual(path, modification.FolderName);
                     Assert.AreEqual("1.3", modification.Version);
 		        }
 		    }
@@ -94,7 +96,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol
                 {
                     changeCount++;
                     Assert.AreEqual("TestNew.txt", modification.FileName);
-                    Assert.AreEqual(@"c:\Sandboxes\Personal2", modification.FolderName);
+                    Assert.AreEqual(path, modification.FolderName);
                     Assert.AreEqual("1.1", modification.Version);
                 }
             }
@@ -117,7 +119,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol
                 {
                     changeCount++;
                     Assert.AreEqual("TestFile2.txt", modification.FileName);
-                    Assert.AreEqual(@"c:\Sandboxes\Personal2", modification.FolderName);
+                    Assert.AreEqual(path, modification.FolderName);
                     Assert.AreEqual("NA", modification.Version);
                 }
             }

--- a/project/UnitTests/Core/SourceControl/MksTest.cs
+++ b/project/UnitTests/Core/SourceControl/MksTest.cs
@@ -69,7 +69,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol
 						  <checkpointOnSuccess>true</checkpointOnSuccess>
 						  <autoDisconnect>true</autoDisconnect>
 					  </sourceControl>
-				 ", sandboxRoot);
+				 ", sandboxRoot).Replace('\\', System.IO.Path.DirectorySeparatorChar);
 		}
 
 		[Test]
@@ -88,7 +88,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol
 		{
 			mks = CreateMks(CreateSourceControlXml(), null, null);
 
-			Assert.AreEqual(@"..\bin\si.exe", mks.Executable);
+			Assert.AreEqual(System.IO.Path.Combine("..", "bin", "si.exe"), mks.Executable);
 			Assert.AreEqual(@"hostname", mks.Hostname);
 			Assert.AreEqual(8722, mks.Port);
 			Assert.AreEqual(@"CCNetUser", mks.User);
@@ -104,10 +104,10 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol
 		public void GetSource()
 		{
             string expectedResyncCommand = string.Format(@"resync --overwriteChanged --restoreTimestamp --forceConfirm=yes --includeDropped -R -S {0} --user=CCNetUser --password=CCNetPassword --quiet", 
-                GeneratePath(@"{0}\myproject.pj", sandboxRoot));
+                GeneratePath(@"{0}\myproject.pj".Replace('\\', System.IO.Path.DirectorySeparatorChar), sandboxRoot));
 			mockExecutorWrapper.Setup(executor => executor.Execute(ExpectedProcessInfo(expectedResyncCommand))).Returns(new ProcessResult(null, null, 0, false)).Verifiable();
 			string expectedAttribCommand = string.Format(@"-R /s {0}", 
-                GeneratePath(@"{0}\*", sandboxRoot));
+                GeneratePath(@"{0}\*".Replace('\\', System.IO.Path.DirectorySeparatorChar), sandboxRoot));
 			mockExecutorWrapper.Setup(executor => executor.Execute(ExpectedProcessInfo("attrib", expectedAttribCommand))).Returns(new ProcessResult(null, null, 0, false)).Verifiable();
 
 			string expectedDisconnectCommand = string.Format(@"disconnect --user=CCNetUser --password=CCNetPassword --quiet --forceConfirm=yes");
@@ -122,10 +122,10 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol
 		public void GetSourceWithSpacesInSandbox()
 		{
 			sandboxRoot = TempFileUtil.GetTempPath("Mks Sand Box");
-            string expectedResyncCommand = string.Format(@"resync --overwriteChanged --restoreTimestamp --forceConfirm=yes --includeDropped -R -S ""{0}\myproject.pj"" --user=CCNetUser --password=CCNetPassword --quiet", sandboxRoot);
+            string expectedResyncCommand = string.Format(@"resync --overwriteChanged --restoreTimestamp --forceConfirm=yes --includeDropped -R -S ""{0}\myproject.pj"" --user=CCNetUser --password=CCNetPassword --quiet".Replace('\\', System.IO.Path.DirectorySeparatorChar), sandboxRoot);
 			mockExecutorWrapper.Setup(executor => executor.Execute(ExpectedProcessInfo(expectedResyncCommand))).Returns(new ProcessResult(null, null, 0, false)).Verifiable();
 			
-			string expectedAttribCommand = string.Format(@"-R /s ""{0}\*""", sandboxRoot);
+			string expectedAttribCommand = string.Format(@"-R /s ""{0}\*""".Replace('\\', System.IO.Path.DirectorySeparatorChar), sandboxRoot);
 			mockExecutorWrapper.Setup(executor => executor.Execute(ExpectedProcessInfo("attrib", expectedAttribCommand))).Returns(new ProcessResult(null, null, 0, false)).Verifiable();
 			
 			string expectedDisconnectCommand = string.Format(@"disconnect --user=CCNetUser --password=CCNetPassword --quiet --forceConfirm=yes");
@@ -139,7 +139,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol
 		[Test]
 		public void CheckpointSourceOnSuccessfulBuild()
 		{
-            string path = GeneratePath(@"{0}\myproject.pj", sandboxRoot);
+            string path = GeneratePath(@"{0}\myproject.pj".Replace('\\', System.IO.Path.DirectorySeparatorChar), sandboxRoot);
 			string expectedCommand = string.Format(@"checkpoint -d ""Cruise Control.Net Build - 20"" -L ""Build - 20"" -R -S {0} --user=CCNetUser --password=CCNetPassword --quiet", path);
 			ProcessInfo expectedProcessInfo = ExpectedProcessInfo(expectedCommand);
 			mockExecutorWrapper.Setup(executor => executor.Execute(expectedProcessInfo)).Returns(new ProcessResult(null, null, 0, false)).Verifiable();
@@ -177,7 +177,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol
 			mksHistoryParserWrapper.Setup(parser => parser.Parse(It.IsAny<TextReader>(), FROM, TO)).Returns(new Modification[0]).Verifiable();
 			
             ProcessInfo expectedProcessInfo = ExpectedProcessInfo(string.Format(@"viewsandbox --nopersist --filter=changed:all --xmlapi -R -S {0} --user=CCNetUser --password=CCNetPassword --quiet", 
-                GeneratePath(@"{0}\myproject.pj", sandboxRoot)));
+                GeneratePath(@"{0}\myproject.pj".Replace('\\', System.IO.Path.DirectorySeparatorChar), sandboxRoot)));
 			mockExecutorWrapper.Setup(executor => executor.Execute(expectedProcessInfo)).Returns(new ProcessResult(null, null, 0, false)).Verifiable();
 			
 			string expectedDisconnectCommand = string.Format(@"disconnect --user=CCNetUser --password=CCNetPassword --quiet --forceConfirm=yes");
@@ -203,7 +203,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol
 			mockExecutorWrapper.Setup(executor => executor.Execute(It.IsAny<ProcessInfo>())).Returns(new ProcessResult("", null, 0, false)).Verifiable();
 
             string expectedCommand = string.Format(@"memberinfo --xmlapi --user=CCNetUser --password=CCNetPassword --quiet {0}", 
-                GeneratePath(@"{0}\MyFolder\myFile.file", sandboxRoot));
+                GeneratePath(@"{0}\MyFolder\myFile.file".Replace('\\', System.IO.Path.DirectorySeparatorChar), sandboxRoot));
 			ProcessInfo expectedProcessInfo = ExpectedProcessInfo(expectedCommand);
 			mockExecutorWrapper.Setup(executor => executor.Execute(expectedProcessInfo)).Returns(new ProcessResult(null, null, 0, false)).Verifiable();
 			
@@ -229,7 +229,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol
 			mockExecutorWrapper.Setup(executor => executor.Execute(It.IsAny<ProcessInfo>())).Returns(new ProcessResult("", null, 0, false)).Verifiable();
 
 			string expectedCommand = string.Format(@"memberinfo --xmlapi --user=CCNetUser --password=CCNetPassword --quiet {0}", 
-                GeneratePath(@"{0}\myFile.file", sandboxRoot));
+                GeneratePath(@"{0}\myFile.file".Replace('\\', System.IO.Path.DirectorySeparatorChar), sandboxRoot));
 			ProcessInfo expectedProcessInfo = ExpectedProcessInfo(expectedCommand);
 			mockExecutorWrapper.Setup(executor => executor.Execute(expectedProcessInfo)).Returns(new ProcessResult(null, null, 0, false)).Verifiable();
 
@@ -294,7 +294,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol
 
 		private static ProcessInfo ExpectedProcessInfo(string arguments)
 		{
-			return ExpectedProcessInfo(@"..\bin\si.exe", arguments);
+			return ExpectedProcessInfo(System.IO.Path.Combine("..", "bin", "si.exe"), arguments);
 		}
 
 		private static ProcessInfo ExpectedProcessInfo(string executable, string arguments)
@@ -319,7 +319,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol
         {
             string basePath = string.Format(path, args);
             if (basePath.Contains(" ")) basePath = "\"" + basePath + "\"";
-            return basePath;
+            return basePath;                                                                      
         }
 	}
 }

--- a/project/UnitTests/Core/SourceControl/MultiIssueTrackerUrlbuilderTest.cs
+++ b/project/UnitTests/Core/SourceControl/MultiIssueTrackerUrlbuilderTest.cs
@@ -28,7 +28,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol
             MultiIssueTrackerUrlBuilder multiIssue = new MultiIssueTrackerUrlBuilder();
             Assert.That(delegate { NetReflector.Read(configFile, multiIssue); },
                         Throws.TypeOf<NetReflectorException>().With.Message.EqualTo(
-                            "Missing Xml node (issueTrackers) for required member (ThoughtWorks.CruiseControl.Core.Sourcecontrol.MultiIssueTrackerUrlBuilder.IssueTrackers).\r\nXml: <issueUrlBuilder type=\"multiIssueTracker\"></issueUrlBuilder>")); 
+                            "Missing Xml node (issueTrackers) for required member (ThoughtWorks.CruiseControl.Core.Sourcecontrol.MultiIssueTrackerUrlBuilder.IssueTrackers)." + Environment.NewLine + "Xml: <issueUrlBuilder type=\"multiIssueTracker\"></issueUrlBuilder>")); 
         }
 
 

--- a/project/UnitTests/Core/SourceControl/Perforce/ProcessP4InitializerTest.cs
+++ b/project/UnitTests/Core/SourceControl/Perforce/ProcessP4InitializerTest.cs
@@ -13,6 +13,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol.Perforce
 		private Mock<ProcessExecutor> processExecutorMock;
 		private Mock<IP4ProcessInfoCreator> processInfoCreatorMock;
 		private ProcessP4Initializer p4Initializer;
+        private string path = Platform.IsWindows ? @"c:\my\working\dir" : @"/my/working/dir";
 
 		[SetUp]
 		public void Setup()
@@ -38,13 +39,13 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol.Perforce
 
 			ProcessInfo processInfo = new ProcessInfo("createclient");
 			ProcessInfo processInfoWithStdInContent = new ProcessInfo("createclient");
-			processInfoWithStdInContent.StandardInputContent = "Client: myClient\n\nRoot:   c:\\my\\working\\dir\n\nView:\n //mydepot/... //myClient/mydepot/...\n //myotherdepot/... //myClient/myotherdepot/...\n";
+			processInfoWithStdInContent.StandardInputContent = "Client: myClient\n\nRoot:   " + path + "\n\nView:\n //mydepot/... //myClient/mydepot/...\n //myotherdepot/... //myClient/myotherdepot/...\n";
 
 			processInfoCreatorMock.Setup(creator => creator.CreateProcessInfo(p4, "client -i")).Returns(processInfo).Verifiable();
 			processExecutorMock.Setup(executor => executor.Execute(processInfoWithStdInContent)).Returns(new ProcessResult("", "", 0, false)).Verifiable();
 
 			// Execute
-			p4Initializer.Initialize(p4, "myProject", @"c:\my\working\dir");
+			p4Initializer.Initialize(p4, "myProject", path);
 
 			// Verify
 			VerifyAll();
@@ -62,13 +63,13 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol.Perforce
 
 			ProcessInfo processInfo = new ProcessInfo("createclient");
 			ProcessInfo processInfoWithStdInContent = new ProcessInfo("createclient");
-			processInfoWithStdInContent.StandardInputContent = string.Format(System.Globalization.CultureInfo.CurrentCulture,"Client: {0}\n\nRoot:   c:\\my\\working\\dir\n\nView:\n //mydepot/... //{0}/mydepot/...\n", expectedClientName);
+			processInfoWithStdInContent.StandardInputContent = string.Format(System.Globalization.CultureInfo.CurrentCulture,"Client: {0}\n\nRoot:   " + path + "\n\nView:\n //mydepot/... //{0}/mydepot/...\n", expectedClientName);
 
 			processInfoCreatorMock.Setup(creator => creator.CreateProcessInfo(p4, "client -i")).Returns(processInfo).Verifiable();
 			processExecutorMock.Setup(executor => executor.Execute(processInfoWithStdInContent)).Returns(new ProcessResult("", "", 0, false)).Verifiable();
 
 			// Execute
-			p4Initializer.Initialize(p4, projectName, @"c:\my\working\dir");
+			p4Initializer.Initialize(p4, projectName, path);
 
 			// Verify
 			Assert.AreEqual(expectedClientName, p4.Client);
@@ -99,7 +100,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol.Perforce
 			p4.View = "ThisIsNotAValidView";
 			try
 			{
-				p4Initializer.Initialize(p4, "myProject", @"c:\my\working\dir");
+				p4Initializer.Initialize(p4, "myProject", path);
 				Assert.Fail("Should check for a valid view");
 			}
 			catch (CruiseControlException e)
@@ -118,7 +119,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol.Perforce
 			processInfoCreatorMock.Setup(creator => creator.CreateProcessInfo(It.IsAny<P4>(), It.IsAny<string>())).Returns(new ProcessInfo("")).Verifiable();
 			processExecutorMock.Setup(executor => executor.Execute(It.IsAny<ProcessInfo>())).Returns(new ProcessResult("", "", 0, false)).Verifiable();
 
-			p4Initializer.Initialize(p4, "myProject", @"c:\my\working\dir");
+			p4Initializer.Initialize(p4, "myProject", path);
 			VerifyAll();
 		}
 
@@ -134,7 +135,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol.Perforce
 
 			ProcessInfo processInfo = new ProcessInfo("createclient");
 			ProcessInfo processInfoWithStdInContent = new ProcessInfo("createclient");
-			processInfoWithStdInContent.StandardInputContent = string.Format(System.Globalization.CultureInfo.CurrentCulture,"Client: {0}\n\nRoot:   c:\\my\\working\\dir\n\nView:\n //mydepot/... //{0}/mydepot/...\n", expectedClientName);
+			processInfoWithStdInContent.StandardInputContent = string.Format(System.Globalization.CultureInfo.CurrentCulture,"Client: {0}\n\nRoot:   " + path + "\n\nView:\n //mydepot/... //{0}/mydepot/...\n", expectedClientName);
 
 			processInfoCreatorMock.Setup(creator => creator.CreateProcessInfo(p4, "client -i")).Returns(processInfo).Verifiable();
 			processExecutorMock.Setup(executor => executor.Execute(processInfoWithStdInContent)).Returns(new ProcessResult("This is standard out", "This is standard error", 1, false)).Verifiable();
@@ -142,7 +143,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol.Perforce
 			// Execute
 			try
 			{
-				p4Initializer.Initialize(p4, projectName, @"c:\my\working\dir");
+				p4Initializer.Initialize(p4, projectName, path);
 				Assert.Fail("Should throw an exception since process result has a non zero exit code");
 			}
 			catch (CruiseControlException e)

--- a/project/UnitTests/Core/SourceControl/PvcsHistoryParserTest.cs
+++ b/project/UnitTests/Core/SourceControl/PvcsHistoryParserTest.cs
@@ -350,7 +350,7 @@ Author id: Admin     lines deleted/added/moved: 0/0/0
 Initial revision.
 ===================================
 --------------------------------------------------------------------------------
-				".Replace(windowsPath, path);
+				".Replace(windowsPath, path).Replace("\\", System.IO.Path.DirectorySeparatorChar.ToString());
             } 
         }
 

--- a/project/UnitTests/Core/SourceControl/PvcsHistoryParserTest.cs
+++ b/project/UnitTests/Core/SourceControl/PvcsHistoryParserTest.cs
@@ -13,6 +13,9 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol
         public static DateTime OLDEST_ENTRY = DateTime.Parse("2000-Jan-01 13:34:52");
         public static DateTime NEWEST_ENTRY = DateTime.Parse("2005-Sep-13 13:34:52");
 
+        private static string windowsPath = @"D:\root\PVCS\vm\common\SampleDB\archives\chess\client";
+        private string path = Platform.IsWindows ? windowsPath : @"/root/PVCS/vm/common/SampleDB/archives/chess/client";
+
         private PvcsHistoryParser parser;
         private DateTimeFormatInfo dfi;
 
@@ -43,7 +46,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol
             expected[0].EmailAddress = null;
             expected[0].Version = "1.4";
             expected[0].FileName = @"ChessViewer.java-arc";
-            expected[0].FolderName = @"D:\root\PVCS\vm\common\SampleDB\archives\chess\client";
+            expected[0].FolderName = path;
             expected[0].ModifiedTime = DateTime.Parse("2/1/00 4:52:46 PM", dfi);
             expected[0].Type = "Checked in";
             expected[0].UserName = "kerstinb";
@@ -55,7 +58,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol
 
         #region Pvcs Version Information
 
-        private static TextReader ContentReader
+        private TextReader ContentReader
         {
             get { return new StringReader(PVCS_VERSION_INFO); }
         }
@@ -68,7 +71,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol
             mod[0].EmailAddress = null;
             mod[0].Version = "1.2";
             mod[0].FileName = @"ChessViewer.java-arc";
-            mod[0].FolderName = @"D:\root\PVCS\vm\common\SampleDB\archives\chess\client";
+            mod[0].FolderName = path;
             mod[0].ModifiedTime = DateTime.Parse("2/1/00 4:52:46 PM", dfi);
             mod[0].Type = "Checked in";
             mod[0].UserName = "kerstinb";
@@ -78,7 +81,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol
             mod[1].EmailAddress = null;
             mod[1].Version = "1.1";
             mod[1].FileName = @"ChessViewer.java-arc";
-            mod[1].FolderName = @"D:\root\PVCS\vm\common\SampleDB\archives\chess\client";
+            mod[1].FolderName = path;
             mod[1].ModifiedTime = DateTime.Parse("2/1/00 4:52:46 PM", dfi);
             mod[1].Type = "Checked in";
             mod[1].UserName = "kerstinb";
@@ -88,7 +91,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol
             mod[2].EmailAddress = null;
             mod[2].Version = "1.4";
             mod[2].FileName = @"ChessViewer.java-arc";
-            mod[2].FolderName = @"D:\root\PVCS\vm\common\SampleDB\archives\chess\client";
+            mod[2].FolderName = path;
             mod[2].ModifiedTime = DateTime.Parse("2/1/00 4:52:46 PM", dfi);
             mod[2].Type = "Checked in";
             mod[2].UserName = "kerstinb";
@@ -98,7 +101,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol
             mod[3].EmailAddress = null;
             mod[3].Version = "1.3";
             mod[3].FileName = @"ChessViewer.java-arc";
-            mod[3].FolderName = @"D:\root\PVCS\vm\common\SampleDB\archives\chess\client";
+            mod[3].FolderName = path;
             mod[3].ModifiedTime = DateTime.Parse("2/1/00 4:52:46 PM", dfi);
             mod[3].Type = "Checked in";
             mod[3].UserName = "kerstinb";
@@ -115,7 +118,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol
             mod[0].EmailAddress = null;
             mod[0].Version = "1.3";
             mod[0].FileName = @"BoardOptions.java-arc";
-            mod[0].FolderName = @"D:\root\PVCS\vm\common\SampleDB\archives\chess\client";
+            mod[0].FolderName = path;
             mod[0].ModifiedTime = DateTime.Parse("2/1/00 4:22:36 PM", dfi);
             mod[0].Type = "Checked in";
             mod[0].UserName = "kerstinb";
@@ -125,7 +128,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol
             mod[1].EmailAddress = null;
             mod[1].Version = "1.2";
             mod[1].FileName = @"ChessRules.java-arc";
-            mod[1].FolderName = @"D:\root\PVCS\vm\common\SampleDB\archives\chess\client";
+            mod[1].FolderName = path;
             mod[1].ModifiedTime = DateTime.Parse("2/1/00 4:26:14 PM", dfi);
             mod[1].Type = "Checked in";
             mod[1].UserName = "kerstinb";
@@ -135,7 +138,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol
             mod[2].EmailAddress = null;
             mod[2].Version = "1.1";
             mod[2].FileName = @"chessviewer.html-arc";
-            mod[2].FolderName = @"D:\root\PVCS\vm\common\SampleDB\archives\chess\client";
+            mod[2].FolderName = path;
             mod[2].ModifiedTime = DateTime.Parse("5/18/98 4:46:38 AM", dfi);
             mod[2].Type = "Checked in";
             mod[2].UserName = "kerstinb";
@@ -145,7 +148,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol
             mod[3].EmailAddress = null;
             mod[3].Version = "1.2";
             mod[3].FileName = @"ChessViewer.java-arc";
-            mod[3].FolderName = @"D:\root\PVCS\vm\common\SampleDB\archives\chess\client";
+            mod[3].FolderName = path;
             mod[3].ModifiedTime = DateTime.Parse("2/1/00 4:52:46 PM", dfi);
             mod[3].Type = "Checked in";
             mod[3].UserName = "kerstinb";
@@ -153,7 +156,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol
             return mod;
         }
 
-        private static string PVCS_VERSION_INFO =
+        private string PVCS_VERSION_INFO { get { return
             @"
 Change History  
 
@@ -347,7 +350,9 @@ Author id: Admin     lines deleted/added/moved: 0/0/0
 Initial revision.
 ===================================
 --------------------------------------------------------------------------------
-				";
+				".Replace(windowsPath, path);
+            } 
+        }
 
         #endregion
     }

--- a/project/UnitTests/Core/SourceControl/RobocopyHistoryParserTest.cs
+++ b/project/UnitTests/Core/SourceControl/RobocopyHistoryParserTest.cs
@@ -16,6 +16,9 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol
 
 		private RobocopyHistoryParser parser = new RobocopyHistoryParser();
 
+        private static string windowsPath = @"E:\copytest";
+        private string path = Platform.IsWindows ? windowsPath : @"/copytest";
+
 		[Test]
 		public void ParseNoChange()
 		{
@@ -33,28 +36,28 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol
 
 			Modification mod0 = new Modification();
 			mod0.Type = "deleted";
-			mod0.FolderName = @"E:\copytest\dst\dir2";
+			mod0.FolderName = Path.Combine(path, "dst", "dir2");
 
 			Assert.AreEqual(modifications[0], mod0);
 
 			Modification mod1 = new Modification();
 			mod1.Type = "deleted";
 			mod1.FileName = "deleted.txt";
-			mod1.FolderName = @"E:\copytest\dst\dir2";
+			mod1.FolderName = Path.Combine(path, "dst", "dir2");
 
 			Assert.AreEqual(modifications[1], mod1);
 
 			Modification mod2 = new Modification();
 			mod2.Type = "deleted";
 			mod2.FileName = "delete.txt";
-			mod2.FolderName = @"E:\copytest\dst";
+			mod2.FolderName = Path.Combine(path, "dst");
 
 			Assert.AreEqual(modifications[2], mod2);
 
 			Modification mod3 = new Modification();
 			mod3.Type = "added";
 			mod3.FileName = "file2.txt";
-			mod3.FolderName = @"E:\copytest\src";
+			mod3.FolderName = Path.Combine(path, "src");
 			mod3.ModifiedTime = CreateDate("2008/02/06 09:16:49");
 
 			Assert.AreEqual(modifications[3], mod3);
@@ -62,7 +65,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol
 			Modification mod4 = new Modification();
 			mod4.Type = "modified";
 			mod4.FileName = "file3.txt";
-			mod4.FolderName = @"E:\copytest\src";
+			mod4.FolderName = Path.Combine(path, "src");
 			mod4.ModifiedTime = CreateDate("2008/02/06 09:35:50");
 
 			Assert.AreEqual(modifications[4], mod4);
@@ -70,7 +73,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol
 			Modification mod5 = new Modification();
 			mod5.Type = "added";
 			mod5.FileName = "file";
-			mod5.FolderName = @"E:\copytest\src\dir with a space";
+			mod5.FolderName = Path.Combine(path, "src", "dir with a space");
 			mod5.ModifiedTime = CreateDate("2008/02/07 07:55:32");
 
 			Assert.AreEqual(modifications[5], mod5);
@@ -78,7 +81,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol
 			Modification mod6 = new Modification();
 			mod6.Type = "added";
 			mod6.FileName = "file with a space.txt";
-			mod6.FolderName = @"E:\copytest\src\dir with a space";
+			mod6.FolderName = Path.Combine(path, "src", "dir with a space");
 			mod6.ModifiedTime = CreateDate("2008/02/07 07:55:38");
 
 			Assert.AreEqual(modifications[6], mod6);
@@ -86,7 +89,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol
 			Modification mod7 = new Modification();
 			mod7.Type = "added";
 			mod7.FileName = "file1.txt";
-			mod7.FolderName = @"E:\copytest\src\dir1";
+			mod7.FolderName = Path.Combine(path, "src", "dir1");
 			mod7.ModifiedTime = CreateDate("2008/02/06 09:31:26");
 
 			Assert.AreEqual(modifications[7], mod7);
@@ -102,7 +105,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol
 		// We require these switches...
 		// /V /L /MIR /X /TS /FP /NDL /NP /NS /NJH /NJS
 
-		public static string LOG_CONTENT =
+		public string LOG_CONTENT { get { return
 @"
 	*EXTRA Dir  	E:\copytest\dst\dir2\
 	  *EXTRA File 		 2008/02/06 09:31:37	E:\copytest\dst\dir2\deleted.txt
@@ -113,7 +116,9 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol
 	    New File  		 2008/02/07 07:55:32	E:\copytest\src\dir with a space\file
 	    New File  		 2008/02/07 07:55:38	E:\copytest\src\dir with a space\file with a space.txt
 	    New File  		 2008/02/06 09:31:26	E:\copytest\src\dir1\file1.txt
-";
+".Replace(windowsPath, path).Replace('\\', Path.DirectorySeparatorChar);
+            }
+        }
 	}
 }
 

--- a/project/UnitTests/Core/SourceControl/StarTeamHistoryParserTest.cs
+++ b/project/UnitTests/Core/SourceControl/StarTeamHistoryParserTest.cs
@@ -219,7 +219,7 @@ for Star team
 			mod[2].UserName = "Ahsanul Zaki";
 
 			mod[3] = new Modification();
-			mod[3].Comment = "fake test file\r\nfor Star team\n";
+			mod[3].Comment = "fake test file" + Environment.NewLine + "for Star team\n";
 			mod[3].EmailAddress = @"N/A";
 			mod[3].FileName = @"akz last.gif";
 			mod[3].FolderName = @"D:\Projects\DD.NET";

--- a/project/UnitTests/Core/SourceControl/Telelogic/SynergyClientTest.cs
+++ b/project/UnitTests/Core/SourceControl/Telelogic/SynergyClientTest.cs
@@ -89,10 +89,10 @@ Warning: CM Synergy startup failed.
 		{
 			// test non-default configured values
 			SynergyConnectionInfo info = new SynergyConnectionInfo();
-			info.Database = @"\\myserver\share\mydatabase";
+			info.Database = System.IO.Path.DirectorySeparatorChar + System.IO.Path.Combine("myserver", "share", "mydatabase");
 			Assert.AreEqual(@"mydatabase", info.DatabaseName);
 
-			info.Database = @"\\myserver\share\mydatabase\";
+			info.Database = System.IO.Path.DirectorySeparatorChar + System.IO.Path.Combine("myserver", "share", "mydatabase") + System.IO.Path.DirectorySeparatorChar;
 			Assert.AreEqual(@"mydatabase", info.DatabaseName);
 		}
 

--- a/project/UnitTests/Core/SourceControl/VssTest.cs
+++ b/project/UnitTests/Core/SourceControl/VssTest.cs
@@ -13,7 +13,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol
 	[TestFixture]
 	public class VssTest : ProcessExecutorTestFixtureBase
 	{
-		public const string DEFAULT_SS_EXE_PATH = @"C:\Program Files\Microsoft Visual Studio\VSS\win32\ss.exe";
+		public string DEFAULT_SS_EXE_PATH = Platform.IsWindows ? @"C:\Program Files\Microsoft Visual Studio\VSS\win32\ss.exe" : @"/Program Files/Microsoft Visual Studio/VSS/win32/ss.exe";
 
 		private Mock<IRegistry> mockRegistry;
 		private VssHistoryParser historyParser;
@@ -100,8 +100,10 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol
 		[Test]
 		public void ReadDefaultExecutableFromRegistry()
 		{
-			mockRegistry.Setup(registry => registry.GetExpectedLocalMachineSubKeyValue(Vss.SS_REGISTRY_PATH, Vss.SS_REGISTRY_KEY)).Returns(@"C:\Program Files\Microsoft Visual Studio\VSS\win32\SSSCC.DLL").Verifiable();
-			Assert.AreEqual(@"C:\Program Files\Microsoft Visual Studio\VSS\win32\ss.exe", vss.Executable);
+			mockRegistry.Setup(registry => registry.GetExpectedLocalMachineSubKeyValue(Vss.SS_REGISTRY_PATH, Vss.SS_REGISTRY_KEY)).
+                Returns(Platform.IsWindows ? @"C:\Program Files\Microsoft Visual Studio\VSS\win32\SSSCC.DLL" : "/Program Files/Microsoft Visual Studio/VSS/win32/SSSCC.DLL").
+                Verifiable();
+			Assert.AreEqual(DEFAULT_SS_EXE_PATH, vss.Executable);
 		}
 
 		[Test]

--- a/project/UnitTests/Core/SourceControl/VstsTest.cs
+++ b/project/UnitTests/Core/SourceControl/VstsTest.cs
@@ -45,7 +45,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol
         public void SetUp()
         {
 
-            CreateProcessExecutorMock("mockPath\\TF.exe");
+            CreateProcessExecutorMock(System.IO.Path.Combine("mockPath", "TF.exe"));
             mockRegistry = new RegistryStub();
             historyParser = new VstsHistoryParser();
 

--- a/project/UnitTests/Core/Tasks/AntsPerformanceProfilerTaskTests.cs
+++ b/project/UnitTests/Core/Tasks/AntsPerformanceProfilerTaskTests.cs
@@ -362,19 +362,21 @@
         [Test]
         public void XmlArgsFilesExcludesWorkingDirectoryWhenRooted()
         {
+            string filename = Platform.IsWindows ? @"c:\args.xml" : "/args.xml";
+        
             var appName = "testApp.exe";
             var result = GenerateResultMock();
             var executablePath = Path.Combine(defaultWorkingDir, "Profile");
             var executor = GenerateExecutorMock(
                 executablePath,
-                this.defaultExecutableArgs + " /e:" + Path.Combine(defaultWorkingDir, appName) + " /argfile:c:\\args.xml",
+                this.defaultExecutableArgs + " /e:" + Path.Combine(defaultWorkingDir, appName) + " /argfile:" + filename,
                 defaultWorkingDir,
                 600000);
             var fileSystemMock = this.InitialiseFileSystemMock(executablePath);
             var logger = mocks.Create<ILogger>().Object;
             var task = new AntsPerformanceProfilerTask(executor, fileSystemMock, logger) { PublishFiles = false };
             task.Application = appName;
-            task.XmlArgsFile = "c:\\args.xml";
+            task.XmlArgsFile = filename;
 
             Mock.Get(result).SetupProperty(_result => _result.Status);
             result.Status = IntegrationStatus.Unknown;
@@ -450,7 +452,7 @@
             Mock.Get(result).SetupGet(_result => _result.IntegrationProperties).Returns(new Dictionary<string, string>());
             Mock.Get(result).SetupGet(_result => _result.Label).Returns("1");
             Mock.Get(result).Setup(_result => _result.AddTaskResult(It.IsAny<ITaskResult>())).Verifiable();
-            Mock.Get(result).Setup(_result => _result.BaseFromArtifactsDirectory("1")).Returns(string.Concat(artefactDir, "\\1"));
+            Mock.Get(result).Setup(_result => _result.BaseFromArtifactsDirectory("1")).Returns(System.IO.Path.Combine(artefactDir, "1"));
             return result;
         }
 

--- a/project/UnitTests/Core/Tasks/DevenvTaskTest.cs
+++ b/project/UnitTests/Core/Tasks/DevenvTaskTest.cs
@@ -96,7 +96,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Tasks
             mockRegistry2.Setup(registry => registry.GetLocalMachineSubKeyValue(DevenvTask.VS2012_REGISTRY_PATH, DevenvTask.VS_REGISTRY_KEY)).Returns(() => null).Verifiable();
             mockRegistry2.Setup(registry => registry.GetLocalMachineSubKeyValue(DevenvTask.VS2010_REGISTRY_PATH, DevenvTask.VS_REGISTRY_KEY)).Returns(DEVENV_2010_PATH).Verifiable();
 
-            Assert.AreEqual(DEVENV_2010_PATH + "devenv.com", task2.Executable);
+            Assert.AreEqual(System.IO.Path.Combine(DEVENV_2010_PATH, "devenv.com"), task2.Executable);
             mockRegistry2.Verify();
             mockProcessExecutor.Verify();
         }
@@ -111,7 +111,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Tasks
             mockRegistry2.Setup(registry => registry.GetLocalMachineSubKeyValue(DevenvTask.VS2012_REGISTRY_PATH, DevenvTask.VS_REGISTRY_KEY)).Returns(() => null).Verifiable();
             mockRegistry2.Setup(registry => registry.GetLocalMachineSubKeyValue(DevenvTask.VS2010_REGISTRY_PATH, DevenvTask.VS_REGISTRY_KEY)).Returns(() => null).Verifiable();
             mockRegistry2.Setup(registry => registry.GetLocalMachineSubKeyValue(DevenvTask.VS2008_REGISTRY_PATH, DevenvTask.VS_REGISTRY_KEY)).Returns(DEVENV_2008_PATH).Verifiable();
-            Assert.AreEqual(DEVENV_2008_PATH + "devenv.com", task2.Executable);
+            Assert.AreEqual(System.IO.Path.Combine(DEVENV_2008_PATH, "devenv.com"), task2.Executable);
             mockRegistry2.Verify();
             mockProcessExecutor.Verify();
         }
@@ -126,7 +126,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Tasks
 
             task2.Version = "10.0";
 
-            Assert.AreEqual(DEVENV_2010_PATH + "devenv.com", task2.Executable);
+            Assert.AreEqual(System.IO.Path.Combine(DEVENV_2010_PATH, "devenv.com"), task2.Executable);
             mockRegistry2.Verify();
             mockProcessExecutor.Verify();
         }
@@ -141,7 +141,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Tasks
 
 			task2.Version = "9.0";
 
-			Assert.AreEqual(DEVENV_2008_PATH + "devenv.com", task2.Executable);
+			Assert.AreEqual(System.IO.Path.Combine(DEVENV_2008_PATH, "devenv.com"), task2.Executable);
 			mockRegistry2.Verify();
 			mockProcessExecutor.Verify();
 		}
@@ -156,7 +156,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Tasks
 
             task2.Version = "VS2010";
 
-            Assert.AreEqual(DEVENV_2010_PATH + "devenv.com", task2.Executable);
+            Assert.AreEqual(System.IO.Path.Combine(DEVENV_2010_PATH, "devenv.com"), task2.Executable);
             mockRegistry2.Verify();
             mockProcessExecutor.Verify();
         }
@@ -171,7 +171,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Tasks
 
             task2.Version = "VS2008";
 
-            Assert.AreEqual(DEVENV_2008_PATH + "devenv.com", task2.Executable);
+            Assert.AreEqual(System.IO.Path.Combine(DEVENV_2008_PATH, "devenv.com"), task2.Executable);
             mockRegistry2.Verify();
             mockProcessExecutor.Verify();
         }
@@ -187,7 +187,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Tasks
             mockRegistry2.Setup(registry => registry.GetLocalMachineSubKeyValue(DevenvTask.VS2010_REGISTRY_PATH, DevenvTask.VS_REGISTRY_KEY)).Returns(() => null).Verifiable();
             mockRegistry2.Setup(registry => registry.GetLocalMachineSubKeyValue(DevenvTask.VS2008_REGISTRY_PATH, DevenvTask.VS_REGISTRY_KEY)).Returns(() => null).Verifiable();
 			mockRegistry2.Setup(registry => registry.GetLocalMachineSubKeyValue(DevenvTask.VS2005_REGISTRY_PATH, DevenvTask.VS_REGISTRY_KEY)).Returns(DEVENV_2005_PATH).Verifiable();
-			Assert.AreEqual(DEVENV_2005_PATH + "devenv.com", task2.Executable);
+			Assert.AreEqual(System.IO.Path.Combine(DEVENV_2005_PATH, "devenv.com"), task2.Executable);
 			mockRegistry2.Verify();
             mockProcessExecutor.Verify();
         }
@@ -202,7 +202,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Tasks
 
 			task2.Version = "8.0";
 
-			Assert.AreEqual(DEVENV_2005_PATH + "devenv.com", task2.Executable);
+			Assert.AreEqual(System.IO.Path.Combine(DEVENV_2005_PATH, "devenv.com"), task2.Executable);
 			mockRegistry2.Verify();
 			mockProcessExecutor.Verify();
 		}
@@ -217,7 +217,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Tasks
 
 			task2.Version = "VS2005";
 
-			Assert.AreEqual(DEVENV_2005_PATH + "devenv.com", task2.Executable);
+			Assert.AreEqual(System.IO.Path.Combine(DEVENV_2005_PATH, "devenv.com"), task2.Executable);
 			mockRegistry2.Verify();
 			mockProcessExecutor.Verify();
 		}
@@ -234,7 +234,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Tasks
             mockRegistry2.Setup(registry => registry.GetLocalMachineSubKeyValue(DevenvTask.VS2008_REGISTRY_PATH, DevenvTask.VS_REGISTRY_KEY)).Returns(() => null).Verifiable();
             mockRegistry2.Setup(registry => registry.GetLocalMachineSubKeyValue(DevenvTask.VS2005_REGISTRY_PATH, DevenvTask.VS_REGISTRY_KEY)).Returns(() => null).Verifiable();
 			mockRegistry2.Setup(registry => registry.GetLocalMachineSubKeyValue(DevenvTask.VS2003_REGISTRY_PATH, DevenvTask.VS_REGISTRY_KEY)).Returns(DEVENV_2003_PATH).Verifiable();
-			Assert.AreEqual(DEVENV_2003_PATH + "devenv.com", task2.Executable);
+			Assert.AreEqual(System.IO.Path.Combine(DEVENV_2003_PATH, "devenv.com"), task2.Executable);
 			mockRegistry2.Verify();
             mockProcessExecutor.Verify();
         }
@@ -249,7 +249,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Tasks
 
 			task2.Version = "7.1";
 
-			Assert.AreEqual(DEVENV_2003_PATH + "devenv.com", task2.Executable);
+			Assert.AreEqual(System.IO.Path.Combine(DEVENV_2003_PATH, "devenv.com"), task2.Executable);
 			mockRegistry2.Verify();
 			mockProcessExecutor.Verify();
 		}
@@ -264,7 +264,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Tasks
 
 			task2.Version = "VS2003";
 
-			Assert.AreEqual(DEVENV_2003_PATH + "devenv.com", task2.Executable);
+			Assert.AreEqual(System.IO.Path.Combine(DEVENV_2003_PATH, "devenv.com"), task2.Executable);
 			mockRegistry2.Verify();
 			mockProcessExecutor.Verify();
 		}
@@ -283,7 +283,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Tasks
             mockRegistry2.Setup(registry => registry.GetLocalMachineSubKeyValue(DevenvTask.VS2003_REGISTRY_PATH, DevenvTask.VS_REGISTRY_KEY)).Returns(() => null).Verifiable();
             mockRegistry2.Setup(registry => registry.GetLocalMachineSubKeyValue(DevenvTask.VS2002_REGISTRY_PATH, DevenvTask.VS_REGISTRY_KEY)).Returns(DEVENV_2002_PATH).Verifiable();
 
-			Assert.AreEqual(DEVENV_2002_PATH + "devenv.com", task2.Executable);
+			Assert.AreEqual(System.IO.Path.Combine(DEVENV_2002_PATH, "devenv.com"), task2.Executable);
 			mockRegistry2.Verify();
             mockProcessExecutor.Verify();
         }
@@ -298,7 +298,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Tasks
 
 			task2.Version = "7.0";
 
-			Assert.AreEqual(DEVENV_2002_PATH + "devenv.com", task2.Executable);
+			Assert.AreEqual(System.IO.Path.Combine(DEVENV_2002_PATH, "devenv.com"), task2.Executable);
 			mockRegistry2.Verify();
 			mockProcessExecutor.Verify();
 		}
@@ -313,7 +313,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Tasks
 
 			task2.Version = "VS2002";
 
-			Assert.AreEqual(DEVENV_2002_PATH + "devenv.com", task2.Executable);
+			Assert.AreEqual(System.IO.Path.Combine(DEVENV_2002_PATH, "devenv.com"), task2.Executable);
 			mockRegistry2.Verify();
 			mockProcessExecutor.Verify();
 		}

--- a/project/UnitTests/Core/Tasks/DumpValueTaskTest.cs
+++ b/project/UnitTests/Core/Tasks/DumpValueTaskTest.cs
@@ -100,7 +100,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Tasks
         [Test]
         public void WithCarriageReturnRun()
         {
-            BaseTest(new DumpValueItem[] { new DumpValueItem("TestName", "TestValue\r\nWith carriage returns") });
+            BaseTest(new DumpValueItem[] { new DumpValueItem("TestName", "TestValue" + System.Environment.NewLine + "With carriage returns") });
         }
 
         [Test]
@@ -186,17 +186,17 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Tasks
 
         private string GetExpectedXMLContent(DumpValueItem[] Items)
         {
-            StringBuilder builder = new StringBuilder("<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n" +
-                                                      "<ValueDumper>\r\n");
+            StringBuilder builder = new StringBuilder("<?xml version=\"1.0\" encoding=\"utf-8\"?>" + Environment.NewLine +
+                                                      "<ValueDumper>" + Environment.NewLine);
             foreach (DumpValueItem item in Items)
             {
-                builder.Append("  <ValueDumperItem>\r\n");
-                builder.Append("    <Name>" + item.Name + "</Name>\r\n");
+                builder.Append("  <ValueDumperItem>" + Environment.NewLine);
+                builder.Append("    <Name>" + item.Name + "</Name>" + Environment.NewLine);
                 if (item.ValueInCDATA)
-                    builder.Append("    <Value><![CDATA[" + item.Value + "]]></Value>\r\n");
+                    builder.Append("    <Value><![CDATA[" + item.Value + "]]></Value>" + Environment.NewLine);
                 else
-                    builder.Append("    <Value>" + item.Value.Replace("&", "&amp;").Replace("<", "&lt;").Replace(">", "&gt;") + "</Value>\r\n");
-                builder.Append("  </ValueDumperItem>\r\n");
+                    builder.Append("    <Value>" + item.Value.Replace("&", "&amp;").Replace("<", "&lt;").Replace(">", "&gt;") + "</Value>" + Environment.NewLine);
+                builder.Append("  </ValueDumperItem>" + Environment.NewLine);
             }
             builder.Append("</ValueDumper>");
 

--- a/project/UnitTests/Core/Tasks/ExecutableTaskTest.cs
+++ b/project/UnitTests/Core/Tasks/ExecutableTaskTest.cs
@@ -197,8 +197,10 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Tasks
 		[Test]
 		public void IfConfiguredBaseDirectoryIsAbsoluteUseItAtBaseDirectory()
 		{
-			task.ConfiguredBaseDirectory = @"c:\my\base\directory";
-			CheckBaseDirectory(IntegrationResultForWorkingDirectoryTest(), @"c:\my\base\directory");
+            string path = Platform.IsWindows ? @"c:\my\base\directory" : @"/my/base/directory";
+        
+			task.ConfiguredBaseDirectory = path;
+			CheckBaseDirectory(IntegrationResultForWorkingDirectoryTest(), path);
 		}
 
 		private void CheckBaseDirectory(IIntegrationResult result, string expectedBaseDirectory)

--- a/project/UnitTests/Core/Tasks/ModificationWriterTaskTest.cs
+++ b/project/UnitTests/Core/Tasks/ModificationWriterTaskTest.cs
@@ -31,7 +31,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Tasks
 		[Test]
 		public void ShouldWriteOutModificationsToFileAsXml()
 		{
-			mockIO.Setup(fileSystem => fileSystem.Save(@"artifactDir\modifications.xml", It.IsAny<string>())).
+			mockIO.Setup(fileSystem => fileSystem.Save(System.IO.Path.Combine(@"artifactDir", "modifications.xml"), It.IsAny<string>())).
 				Callback<string, string>((file, content) => {
 					XmlUtil.VerifyXmlIsWellFormed(content);
 					XmlElement element = XmlUtil.CreateDocumentElement(content);
@@ -54,7 +54,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Tasks
         {
 
             IntegrationResult result = IntegrationResultMother.CreateSuccessful();
-            string newFileName = string.Format(System.Globalization.CultureInfo.CurrentCulture,"artifactDir\\modifications_{0}.xml",result.StartTime.ToString("yyyyMMddHHmmssfff"));
+            string newFileName = string.Format(System.Globalization.CultureInfo.CurrentCulture, System.IO.Path.Combine("artifactDir", "modifications_{0}.xml"),result.StartTime.ToString("yyyyMMddHHmmssfff"));
 
             mockIO.Setup(fileSystem => fileSystem.Save(newFileName, It.IsAny<string>())).
                 Callback<string, string>((file, content) => {
@@ -78,7 +78,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Tasks
 		[Test]
 		public void ShouldSaveEmptyFileIfNoModificationsSpecified()
 		{
-			mockIO.Setup(fileSystem => fileSystem.Save(@"artifactDir\output.xml", It.IsAny<string>())).
+			mockIO.Setup(fileSystem => fileSystem.Save(System.IO.Path.Combine(@"artifactDir", "output.xml"), It.IsAny<string>())).
 				Callback<string, string>((file, content) => {
 					XmlUtil.VerifyXmlIsWellFormed(content);
 					XmlElement element = XmlUtil.CreateDocumentElement(content);
@@ -97,7 +97,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Tasks
         {
 
             IntegrationResult result = IntegrationResultMother.CreateSuccessful();
-            string newFileName = string.Format(System.Globalization.CultureInfo.CurrentCulture,"artifactDir\\output_{0}.xml", result.StartTime.ToString("yyyyMMddHHmmssfff"));
+            string newFileName = string.Format(System.Globalization.CultureInfo.CurrentCulture, System.IO.Path.Combine("artifactDir", "output_{0}.xml"), result.StartTime.ToString("yyyyMMddHHmmssfff"));
             mockIO.Setup(fileSystem => fileSystem.Save(newFileName, It.IsAny<string>())).
                 Callback<string, string>((file, content) => {
                     XmlUtil.VerifyXmlIsWellFormed(content);
@@ -117,7 +117,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Tasks
 		[Test]
 		public void ShouldRebaseDirectoryRelativeToArtifactDir()
 		{
-			mockIO.Setup(fileSystem => fileSystem.Save(@"artifactDir\relativePath\modifications.xml", It.IsAny<string>())).
+			mockIO.Setup(fileSystem => fileSystem.Save(System.IO.Path.Combine("artifactDir", "relativePath", "modifications.xml"), It.IsAny<string>())).
 				Callback<string, string>((file, content) => {
 					XmlUtil.VerifyXmlIsWellFormed(content);
 					XmlElement element = XmlUtil.CreateDocumentElement(content);
@@ -135,7 +135,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Tasks
         public void ShouldRebaseDirectoryRelativeToArtifactDirWithBuildTimeAppended()
         {
             IntegrationResult result = IntegrationResultMother.CreateSuccessful();
-            string newFileName = string.Format(System.Globalization.CultureInfo.CurrentCulture,"artifactDir\\relativePath\\modifications_{0}.xml", result.StartTime.ToString("yyyyMMddHHmmssfff"));
+            string newFileName = string.Format(System.Globalization.CultureInfo.CurrentCulture, System.IO.Path.Combine("artifactDir", "relativePath", "modifications_{0}.xml"), result.StartTime.ToString("yyyyMMddHHmmssfff"));
 
             mockIO.Setup(fileSystem => fileSystem.Save(newFileName, It.IsAny<string>())).
                 Callback<string, string>((file, content) => {
@@ -155,7 +155,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Tasks
 		[Test]
 		public void ShouldWriteXmlUsingUTF8Encoding()
 		{
-			mockIO.Setup(fileSystem => fileSystem.Save(@"artifactDir\modifications.xml", It.IsAny<string>())).
+			mockIO.Setup(fileSystem => fileSystem.Save(System.IO.Path.Combine("artifactDir", "modifications.xml"), It.IsAny<string>())).
 				Callback<string, string>((file, content) => {
 					Assert.IsTrue(content.StartsWith("<?xml version=\"1.0\" encoding=\"utf-8\"?>"));
 				}).Verifiable();
@@ -171,7 +171,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Tasks
         public void ShouldWriteXmlUsingUTF8EncodingWithBuildTimeAppended()
         {
             IntegrationResult result = IntegrationResultMother.CreateSuccessful();
-            string newFileName = string.Format(System.Globalization.CultureInfo.CurrentCulture,"artifactDir\\modifications_{0}.xml", result.StartTime.ToString("yyyyMMddHHmmssfff"));
+            string newFileName = string.Format(System.Globalization.CultureInfo.CurrentCulture, System.IO.Path.Combine("artifactDir", "modifications_{0}.xml"), result.StartTime.ToString("yyyyMMddHHmmssfff"));
 
             mockIO.Setup(fileSystem => fileSystem.Save(newFileName, It.IsAny<string>())).
                 Callback<string, string>((file, content) => {

--- a/project/UnitTests/Core/Tasks/NDependTaskTests.cs
+++ b/project/UnitTests/Core/Tasks/NDependTaskTests.cs
@@ -29,25 +29,25 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Tasks
         [Test]
         public void ExecuteRunsNDependWithDefaults()
         {
-            var workingDir = "workingDir\\NDependResults";
+            var workingDir = System.IO.Path.Combine("workingDir", "NDependResults");
             var result = GenerateResultMock();
-            var executor = GenerateExecutorMock("workingDir\\NDepend.Console", "workingDir\\NDependResults /OutDir workingDir\\NDependResults", "workingDir", 600000);
+            var executor = GenerateExecutorMock(System.IO.Path.Combine("workingDir", "NDepend.Console"), workingDir + " /OutDir " + workingDir, "workingDir", 600000);
             var fileSystem = mocks.Create<IFileSystem>(MockBehavior.Strict).Object;
             MockSequence sequence = new MockSequence();
             Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.DirectoryExists(workingDir)).Returns(true).Verifiable();
             Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.GetFilesInDirectory(workingDir)).Returns(new string[0]).Verifiable();
-            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.FileExists("workingDir\\NDependResults\\ReportResources.xml")).Returns(false).Verifiable();
+            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.FileExists(System.IO.Path.Combine("workingDir", "NDependResults", "ReportResources.xml"))).Returns(false).Verifiable();
             Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.DirectoryExists(workingDir)).Returns(true).Verifiable();
             Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.GetFilesInDirectory(workingDir)).Returns(new string[] {
-                "workingDir\\NDependResults\\file1.txt",
-                "workingDir\\NDependResults\\file2.xml"
+                System.IO.Path.Combine("workingDir", "NDependResults", "file1.txt"),
+                System.IO.Path.Combine("workingDir", "NDependResults", "file2.xml")
             }).Verifiable();
-            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.DirectoryExists("artefactDir\\1\\NDepend")).Returns(true).Verifiable();
-            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.FileExists("workingDir\\NDependResults\\file1.txt")).Returns(true).Verifiable();
-            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.Copy("workingDir\\NDependResults\\file1.txt", "artefactDir\\1\\NDepend\\file1.txt")).Verifiable();
-            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.FileExists("workingDir\\NDependResults\\file2.xml")).Returns(true).Verifiable();
-            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.Copy("workingDir\\NDependResults\\file2.xml", "artefactDir\\1\\NDepend\\file2.xml")).Verifiable();
-            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.GenerateTaskResultFromFile("workingDir\\NDependResults\\file2.xml")).Returns(mocks.Create<ITaskResult>().Object).Verifiable();
+            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.DirectoryExists(System.IO.Path.Combine("artefactDir", "1", "NDepend"))).Returns(true).Verifiable();
+            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.FileExists(System.IO.Path.Combine("workingDir", "NDependResults", "file1.txt"))).Returns(true).Verifiable();
+            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.Copy(System.IO.Path.Combine("workingDir", "NDependResults", "file1.txt"), System.IO.Path.Combine("artefactDir", "1", "NDepend", "file1.txt"))).Verifiable();
+            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.FileExists(System.IO.Path.Combine("workingDir", "NDependResults", "file2.xml"))).Returns(true).Verifiable();
+            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.Copy(System.IO.Path.Combine("workingDir", "NDependResults", "file2.xml"), System.IO.Path.Combine("artefactDir", "1", "NDepend", "file2.xml"))).Verifiable();
+            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.GenerateTaskResultFromFile(System.IO.Path.Combine("workingDir", "NDependResults", "file2.xml"))).Returns(mocks.Create<ITaskResult>().Object).Verifiable();
             var logger = mocks.Create<ILogger>().Object;
             var task = new NDependTask(executor, fileSystem, logger);
 
@@ -60,26 +60,26 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Tasks
         [Test]
         public void ExecuteWillCreateANewDirectory()
         {
-            var workingDir = "workingDir\\NDependResults";
+            var workingDir = System.IO.Path.Combine("workingDir", "NDependResults");
             var result = GenerateResultMock();
-            var executor = GenerateExecutorMock("workingDir\\NDepend.Console", "workingDir\\NDependResults /OutDir workingDir\\NDependResults", "workingDir", 600000);
+            var executor = GenerateExecutorMock(System.IO.Path.Combine("workingDir", "NDepend.Console"), workingDir + " /OutDir " + workingDir, "workingDir", 600000);
             var fileSystem = mocks.Create<IFileSystem>(MockBehavior.Strict).Object;
             MockSequence sequence = new MockSequence();
             Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.DirectoryExists(workingDir)).Returns(true).Verifiable();
             Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.GetFilesInDirectory(workingDir)).Returns(new string[0]).Verifiable();
-            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.FileExists("workingDir\\NDependResults\\ReportResources.xml")).Returns(false).Verifiable();
+            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.FileExists(System.IO.Path.Combine("workingDir", "NDependResults", "ReportResources.xml"))).Returns(false).Verifiable();
             Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.DirectoryExists(workingDir)).Returns(true).Verifiable();
             Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.GetFilesInDirectory(workingDir)).Returns(new string[] {
-                "workingDir\\NDependResults\\file1.txt",
-                "workingDir\\NDependResults\\file2.xml"
+                System.IO.Path.Combine("workingDir", "NDependResults", "file1.txt"),
+                System.IO.Path.Combine("workingDir", "NDependResults", "file2.xml")
             }).Verifiable();
-            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.DirectoryExists("artefactDir\\1\\NDepend")).Returns(false).Verifiable();
-            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.CreateDirectory("artefactDir\\1\\NDepend")).Verifiable();
-            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.FileExists("workingDir\\NDependResults\\file1.txt")).Returns(true).Verifiable();
-            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.Copy("workingDir\\NDependResults\\file1.txt", "artefactDir\\1\\NDepend\\file1.txt")).Verifiable();
-            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.FileExists("workingDir\\NDependResults\\file2.xml")).Returns(true).Verifiable();
-            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.Copy("workingDir\\NDependResults\\file2.xml", "artefactDir\\1\\NDepend\\file2.xml")).Verifiable();
-            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.GenerateTaskResultFromFile("workingDir\\NDependResults\\file2.xml")).Returns(mocks.Create<ITaskResult>().Object).Verifiable();
+            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.DirectoryExists(System.IO.Path.Combine("artefactDir", "1", "NDepend"))).Returns(false).Verifiable();
+            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.CreateDirectory(System.IO.Path.Combine("artefactDir", "1", "NDepend"))).Verifiable();
+            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.FileExists(System.IO.Path.Combine("workingDir", "NDependResults", "file1.txt"))).Returns(true).Verifiable();
+            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.Copy(System.IO.Path.Combine("workingDir", "NDependResults", "file1.txt"), System.IO.Path.Combine("artefactDir", "1", "NDepend", "file1.txt"))).Verifiable();
+            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.FileExists(System.IO.Path.Combine("workingDir", "NDependResults", "file2.xml"))).Returns(true).Verifiable();
+            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.Copy(System.IO.Path.Combine("workingDir", "NDependResults", "file2.xml"), System.IO.Path.Combine("artefactDir", "1", "NDepend", "file2.xml"))).Verifiable();
+            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.GenerateTaskResultFromFile(System.IO.Path.Combine("workingDir", "NDependResults", "file2.xml"))).Returns(mocks.Create<ITaskResult>().Object).Verifiable();
             var logger = mocks.Create<ILogger>().Object;
             var task = new NDependTask(executor, fileSystem, logger);
 
@@ -92,24 +92,24 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Tasks
         [Test]
         public void ExecuteLoadsContentsFileIfItExists()
         {
-            var workingDir = "workingDir\\NDependResults";
+            var workingDir = System.IO.Path.Combine("workingDir", "NDependResults");
             var result = GenerateResultMock();
-            var executor = GenerateExecutorMock("workingDir\\NDepend.Console", "workingDir\\NDependResults /OutDir workingDir\\NDependResults", "workingDir", 600000);
+            var executor = GenerateExecutorMock(System.IO.Path.Combine("workingDir", "NDepend.Console"), workingDir + " /OutDir " + workingDir, "workingDir", 600000);
             var fileSystem = mocks.Create<IFileSystem>(MockBehavior.Strict).Object;
             MockSequence sequence = new MockSequence();
             Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.DirectoryExists(workingDir)).Returns(true).Verifiable();
             Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.GetFilesInDirectory(workingDir)).Returns(new string[0]).Verifiable();
-            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.FileExists("workingDir\\NDependResults\\ReportResources.xml")).Returns(true).Verifiable();
+            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.FileExists(System.IO.Path.Combine("workingDir", "NDependResults", "ReportResources.xml"))).Returns(true).Verifiable();
             using (var reader = new StringReader("<ReportResources><File>file1.txt</File><File>file2.xml</File></ReportResources>"))
             {
-                Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.Load("workingDir\\NDependResults\\ReportResources.xml")).Returns(reader).Verifiable();
-                Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.DirectoryExists("artefactDir\\1\\NDepend")).Returns(false).Verifiable();
-                Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.CreateDirectory("artefactDir\\1\\NDepend")).Verifiable();
-                Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.FileExists("workingDir\\NDependResults\\file1.txt")).Returns(true).Verifiable();
-                Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.Copy("workingDir\\NDependResults\\file1.txt", "artefactDir\\1\\NDepend\\file1.txt")).Verifiable();
-                Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.FileExists("workingDir\\NDependResults\\file2.xml")).Returns(true).Verifiable();
-                Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.Copy("workingDir\\NDependResults\\file2.xml", "artefactDir\\1\\NDepend\\file2.xml")).Verifiable();
-                Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.GenerateTaskResultFromFile("workingDir\\NDependResults\\file2.xml")).Returns(mocks.Create<ITaskResult>().Object).Verifiable();
+                Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.Load(System.IO.Path.Combine("workingDir", "NDependResults", "ReportResources.xml"))).Returns(reader).Verifiable();
+                Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.DirectoryExists(System.IO.Path.Combine("artefactDir", "1", "NDepend"))).Returns(false).Verifiable();
+                Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.CreateDirectory(System.IO.Path.Combine("artefactDir", "1", "NDepend"))).Verifiable();
+                Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.FileExists(System.IO.Path.Combine("workingDir", "NDependResults", "file1.txt"))).Returns(true).Verifiable();
+                Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.Copy(System.IO.Path.Combine("workingDir", "NDependResults", "file1.txt"), System.IO.Path.Combine("artefactDir", "1", "NDepend", "file1.txt"))).Verifiable();
+                Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.FileExists(System.IO.Path.Combine("workingDir", "NDependResults", "file2.xml"))).Returns(true).Verifiable();
+                Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.Copy(System.IO.Path.Combine("workingDir", "NDependResults", "file2.xml"), System.IO.Path.Combine("artefactDir", "1", "NDepend", "file2.xml"))).Verifiable();
+                Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.GenerateTaskResultFromFile(System.IO.Path.Combine("workingDir", "NDependResults", "file2.xml"))).Returns(mocks.Create<ITaskResult>().Object).Verifiable();
                 var logger = mocks.Create<ILogger>().Object;
                 var task = new NDependTask(executor, fileSystem, logger);
 
@@ -123,17 +123,17 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Tasks
         [Test]
         public void ExecuteFailsIfContentFileHasInvalidRootNode()
         {
-            var workingDir = "workingDir\\NDependResults";
+            var workingDir = System.IO.Path.Combine("workingDir", "NDependResults");
             var result = GenerateResultMock();
-            var executor = GenerateExecutorMock("workingDir\\NDepend.Console", "workingDir\\NDependResults /OutDir workingDir\\NDependResults", "workingDir", 600000);
+            var executor = GenerateExecutorMock(System.IO.Path.Combine("workingDir", "NDepend.Console"), workingDir + " /OutDir " + workingDir, "workingDir", 600000);
             var fileSystem = mocks.Create<IFileSystem>(MockBehavior.Strict).Object;
             MockSequence sequence = new MockSequence();
             Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.DirectoryExists(workingDir)).Returns(true).Verifiable();
             Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.GetFilesInDirectory(workingDir)).Returns(new string[0]).Verifiable();
-            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.FileExists("workingDir\\NDependResults\\ReportResources.xml")).Returns(true).Verifiable();
+            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.FileExists(System.IO.Path.Combine("workingDir", "NDependResults", "ReportResources.xml"))).Returns(true).Verifiable();
             using (var reader = new StringReader("<garbage/>"))
             {
-                Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.Load("workingDir\\NDependResults\\ReportResources.xml")).Returns(reader).Verifiable();
+                Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.Load(System.IO.Path.Combine("workingDir", "NDependResults", "ReportResources.xml"))).Returns(reader).Verifiable();
                 var logger = mocks.Create<ILogger>().Object;
                 var task = new NDependTask(executor, fileSystem, logger);
 
@@ -147,17 +147,17 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Tasks
         [Test]
         public void ExecuteFailsIfContentFileIsInvalid()
         {
-            var workingDir = "workingDir\\NDependResults";
+            var workingDir = System.IO.Path.Combine("workingDir", "NDependResults");
             var result = GenerateResultMock();
-            var executor = GenerateExecutorMock("workingDir\\NDepend.Console", "workingDir\\NDependResults /OutDir workingDir\\NDependResults", "workingDir", 600000);
+            var executor = GenerateExecutorMock(System.IO.Path.Combine("workingDir", "NDepend.Console"), workingDir + " /OutDir " + workingDir, "workingDir", 600000);
             var fileSystem = mocks.Create<IFileSystem>(MockBehavior.Strict).Object;
             MockSequence sequence = new MockSequence();
             Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.DirectoryExists(workingDir)).Returns(true).Verifiable();
             Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.GetFilesInDirectory(workingDir)).Returns(new string[0]).Verifiable();
-            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.FileExists("workingDir\\NDependResults\\ReportResources.xml")).Returns(true).Verifiable();
+            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.FileExists(System.IO.Path.Combine("workingDir", "NDependResults", "ReportResources.xml"))).Returns(true).Verifiable();
             using (var reader = new StringReader("garbage"))
             {
-                Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.Load("workingDir\\NDependResults\\ReportResources.xml")).Returns(reader).Verifiable();
+                Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.Load(System.IO.Path.Combine("workingDir", "NDependResults", "ReportResources.xml"))).Returns(reader).Verifiable();
                 var logger = mocks.Create<ILogger>().Object;
                 var task = new NDependTask(executor, fileSystem, logger);
 
@@ -171,21 +171,21 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Tasks
         [Test]
         public void ExecuteLoadsContentsFileIfItExistsAndSkipsFilesIfMissing()
         {
-            var workingDir = "workingDir\\NDependResults";
+            var workingDir = System.IO.Path.Combine("workingDir", "NDependResults");
             var result = GenerateResultMock();
-            var executor = GenerateExecutorMock("workingDir\\NDepend.Console", "workingDir\\NDependResults /OutDir workingDir\\NDependResults", "workingDir", 600000);
+            var executor = GenerateExecutorMock(System.IO.Path.Combine("workingDir", "NDepend.Console"), workingDir + " /OutDir " + workingDir, "workingDir", 600000);
             var fileSystem = mocks.Create<IFileSystem>(MockBehavior.Strict).Object;
             MockSequence sequence = new MockSequence();
             Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.DirectoryExists(workingDir)).Returns(true).Verifiable();
             Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.GetFilesInDirectory(workingDir)).Returns(new string[0]).Verifiable();
-            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.FileExists("workingDir\\NDependResults\\ReportResources.xml")).Returns(true).Verifiable();
+            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.FileExists(System.IO.Path.Combine("workingDir", "NDependResults", "ReportResources.xml"))).Returns(true).Verifiable();
             using (var reader = new StringReader("<ReportResources><File>file1.txt</File><File>file2.xml</File></ReportResources>"))
             {
-                Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.Load("workingDir\\NDependResults\\ReportResources.xml")).Returns(reader).Verifiable();
-                Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.DirectoryExists("artefactDir\\1\\NDepend")).Returns(false).Verifiable();
-                Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.CreateDirectory("artefactDir\\1\\NDepend")).Verifiable();
-                Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.FileExists("workingDir\\NDependResults\\file1.txt")).Returns(false).Verifiable();
-                Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.FileExists("workingDir\\NDependResults\\file2.xml")).Returns(false).Verifiable();
+                Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.Load(System.IO.Path.Combine("workingDir", "NDependResults", "ReportResources.xml"))).Returns(reader).Verifiable();
+                Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.DirectoryExists(System.IO.Path.Combine("artefactDir", "1", "NDepend"))).Returns(false).Verifiable();
+                Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.CreateDirectory(System.IO.Path.Combine("artefactDir", "1", "NDepend"))).Verifiable();
+                Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.FileExists(System.IO.Path.Combine("workingDir", "NDependResults", "file1.txt"))).Returns(false).Verifiable();
+                Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.FileExists(System.IO.Path.Combine("workingDir", "NDependResults", "file2.xml"))).Returns(false).Verifiable();
                 var logger = mocks.Create<ILogger>().Object;
                 var task = new NDependTask(executor, fileSystem, logger);
 
@@ -199,22 +199,22 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Tasks
         [Test]
         public void ExecuteLoadsContentsFileIfItExistsAndImportsDirectory()
         {
-            var workingDir = "workingDir\\NDependResults";
+            var workingDir = System.IO.Path.Combine("workingDir", "NDependResults");
             var result = GenerateResultMock();
-            var executor = GenerateExecutorMock("workingDir\\NDepend.Console", "workingDir\\NDependResults /OutDir workingDir\\NDependResults", "workingDir", 600000);
+            var executor = GenerateExecutorMock(System.IO.Path.Combine("workingDir", "NDepend.Console"), workingDir + " /OutDir " + workingDir, "workingDir", 600000);
             var fileSystem = mocks.Create<IFileSystem>(MockBehavior.Strict).Object;
             MockSequence sequence = new MockSequence();
             Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.DirectoryExists(workingDir)).Returns(true).Verifiable();
             Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.GetFilesInDirectory(workingDir)).Returns(new string[0]).Verifiable();
-            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.FileExists("workingDir\\NDependResults\\ReportResources.xml")).Returns(true).Verifiable();
+            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.FileExists(System.IO.Path.Combine("workingDir", "NDependResults", "ReportResources.xml"))).Returns(true).Verifiable();
             using (var reader = new StringReader("<ReportResources><Directory>images</Directory></ReportResources>"))
             {
-                Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.Load("workingDir\\NDependResults\\ReportResources.xml")).Returns(reader).Verifiable();
-                Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.GetFilesInDirectory("workingDir\\NDependResults\\images", true)).Returns(new[] { "workingDir\\NDependResults\\images\\test.png" }).Verifiable();
-                Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.DirectoryExists("artefactDir\\1\\NDepend\\images")).Returns(false).Verifiable();
-                Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.CreateDirectory("artefactDir\\1\\NDepend\\images")).Verifiable();
-                Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.FileExists("workingDir\\NDependResults\\images\\test.png")).Returns(true).Verifiable();
-                Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.Copy("workingDir\\NDependResults\\images\\test.png", "artefactDir\\1\\NDepend\\images\\test.png")).Verifiable();
+                Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.Load(System.IO.Path.Combine("workingDir", "NDependResults", "ReportResources.xml"))).Returns(reader).Verifiable();
+                Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.GetFilesInDirectory(System.IO.Path.Combine("workingDir", "NDependResults", "images"), true)).Returns(new[] { System.IO.Path.Combine("workingDir", "NDependResults", "images", "test.png") }).Verifiable();
+                Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.DirectoryExists(System.IO.Path.Combine("artefactDir", "1", "NDepend", "images"))).Returns(false).Verifiable();
+                Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.CreateDirectory(System.IO.Path.Combine("artefactDir", "1", "NDepend", "images"))).Verifiable();
+                Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.FileExists(System.IO.Path.Combine("workingDir", "NDependResults", "images", "test.png"))).Returns(true).Verifiable();
+                Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.Copy(System.IO.Path.Combine("workingDir", "NDependResults", "images", "test.png"), System.IO.Path.Combine("artefactDir", "1", "NDepend", "images", "test.png"))).Verifiable();
                 var logger = mocks.Create<ILogger>().Object;
                 var task = new NDependTask(executor, fileSystem, logger);
 
@@ -228,25 +228,25 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Tasks
         [Test]
         public void CanOverrideExecutable()
         {
-            var workingDir = "workingDir\\NDependResults";
+            var workingDir = System.IO.Path.Combine("workingDir", "NDependResults");
             var result = GenerateResultMock();
-            var executor = GenerateExecutorMock("workingDir\\ndepend-app.exe", "workingDir\\NDependResults /OutDir workingDir\\NDependResults", "workingDir", 600000);
+            var executor = GenerateExecutorMock(System.IO.Path.Combine("workingDir", "ndepend-app.exe"), workingDir + " /OutDir " + workingDir, "workingDir", 600000);
             var fileSystem = mocks.Create<IFileSystem>(MockBehavior.Strict).Object;
             MockSequence sequence = new MockSequence();
             Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.DirectoryExists(workingDir)).Returns(true).Verifiable();
             Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.GetFilesInDirectory(workingDir)).Returns(new string[0]).Verifiable();
-            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.FileExists("workingDir\\NDependResults\\ReportResources.xml")).Returns(false).Verifiable();
+            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.FileExists(System.IO.Path.Combine("workingDir", "NDependResults", "ReportResources.xml"))).Returns(false).Verifiable();
             Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.DirectoryExists(workingDir)).Returns(true).Verifiable();
             Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.GetFilesInDirectory(workingDir)).Returns(new string[] {
-                "workingDir\\NDependResults\\file1.txt",
-                "workingDir\\NDependResults\\file2.xml"
+                System.IO.Path.Combine("workingDir", "NDependResults", "file1.txt"),
+                System.IO.Path.Combine("workingDir", "NDependResults", "file2.xml")
             }).Verifiable();
-            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.DirectoryExists("artefactDir\\1\\NDepend")).Returns(true).Verifiable();
-            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.FileExists("workingDir\\NDependResults\\file1.txt")).Returns(true).Verifiable();
-            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.Copy("workingDir\\NDependResults\\file1.txt", "artefactDir\\1\\NDepend\\file1.txt")).Verifiable();
-            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.FileExists("workingDir\\NDependResults\\file2.xml")).Returns(true).Verifiable();
-            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.Copy("workingDir\\NDependResults\\file2.xml", "artefactDir\\1\\NDepend\\file2.xml")).Verifiable();
-            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.GenerateTaskResultFromFile("workingDir\\NDependResults\\file2.xml")).Returns(mocks.Create<ITaskResult>().Object).Verifiable();
+            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.DirectoryExists(System.IO.Path.Combine("artefactDir", "1", "NDepend"))).Returns(true).Verifiable();
+            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.FileExists(System.IO.Path.Combine("workingDir", "NDependResults", "file1.txt"))).Returns(true).Verifiable();
+            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.Copy(System.IO.Path.Combine("workingDir", "NDependResults", "file1.txt"), System.IO.Path.Combine("artefactDir", "1", "NDepend", "file1.txt"))).Verifiable();
+            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.FileExists(System.IO.Path.Combine("workingDir", "NDependResults", "file2.xml"))).Returns(true).Verifiable();
+            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.Copy(System.IO.Path.Combine("workingDir", "NDependResults", "file2.xml"), System.IO.Path.Combine("artefactDir", "1", "NDepend", "file2.xml"))).Verifiable();
+            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.GenerateTaskResultFromFile(System.IO.Path.Combine("workingDir", "NDependResults", "file2.xml"))).Returns(mocks.Create<ITaskResult>().Object).Verifiable();
             var logger = mocks.Create<ILogger>().Object;
             var task = new NDependTask(executor, fileSystem, logger);
             task.Executable = "ndepend-app.exe";
@@ -260,25 +260,25 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Tasks
         [Test]
         public void CanUsePathsWithSpaces()
         {
-            var workingDir = "working Dir\\NDependResults";
+            var workingDir = System.IO.Path.Combine("working Dir", "NDependResults");
             var result = GenerateResultMock("working Dir", "artefact Dir");
-            var executor = GenerateExecutorMock("working Dir\\ndepend-app.exe", "\"working Dir\\NDependResults\" /OutDir \"working Dir\\NDependResults\"", "working Dir", 600000);
+            var executor = GenerateExecutorMock(System.IO.Path.Combine("working Dir", "ndepend-app.exe"), "\"" + workingDir + "\" /OutDir \"" + workingDir + "\"", "working Dir", 600000);
             var fileSystem = mocks.Create<IFileSystem>(MockBehavior.Strict).Object;
             MockSequence sequence = new MockSequence();
             Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.DirectoryExists(workingDir)).Returns(true).Verifiable();
             Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.GetFilesInDirectory(workingDir)).Returns(new string[0]).Verifiable();
-            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.FileExists("working Dir\\NDependResults\\ReportResources.xml")).Returns(false).Verifiable();
+            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.FileExists(System.IO.Path.Combine("working Dir", "NDependResults", "ReportResources.xml"))).Returns(false).Verifiable();
             Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.DirectoryExists(workingDir)).Returns(true).Verifiable();
             Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.GetFilesInDirectory(workingDir)).Returns(new string[] {
-                "working Dir\\NDependResults\\file1.txt",
-                "working Dir\\NDependResults\\file2.xml"
+                System.IO.Path.Combine("working Dir", "NDependResults", "file1.txt"),
+                System.IO.Path.Combine("working Dir", "NDependResults", "file2.xml")
             }).Verifiable();
-            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.DirectoryExists("artefact Dir\\1\\NDepend")).Returns(true).Verifiable();
-            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.FileExists("working Dir\\NDependResults\\file1.txt")).Returns(true).Verifiable();
-            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.Copy("working Dir\\NDependResults\\file1.txt", "artefact Dir\\1\\NDepend\\file1.txt")).Verifiable();
-            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.FileExists("working Dir\\NDependResults\\file2.xml")).Returns(true).Verifiable();
-            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.Copy("working Dir\\NDependResults\\file2.xml", "artefact Dir\\1\\NDepend\\file2.xml")).Verifiable();
-            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.GenerateTaskResultFromFile("working Dir\\NDependResults\\file2.xml")).Returns(mocks.Create<ITaskResult>().Object).Verifiable();
+            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.DirectoryExists(System.IO.Path.Combine("artefact Dir", "1", "NDepend"))).Returns(true).Verifiable();
+            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.FileExists(System.IO.Path.Combine("working Dir", "NDependResults", "file1.txt"))).Returns(true).Verifiable();
+            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.Copy(System.IO.Path.Combine("working Dir", "NDependResults", "file1.txt"), System.IO.Path.Combine("artefact Dir", "1", "NDepend", "file1.txt"))).Verifiable();
+            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.FileExists(System.IO.Path.Combine("working Dir", "NDependResults", "file2.xml"))).Returns(true).Verifiable();
+            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.Copy(System.IO.Path.Combine("working Dir", "NDependResults", "file2.xml"), System.IO.Path.Combine("artefact Dir", "1", "NDepend", "file2.xml"))).Verifiable();
+            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.GenerateTaskResultFromFile(System.IO.Path.Combine("working Dir", "NDependResults", "file2.xml"))).Returns(mocks.Create<ITaskResult>().Object).Verifiable();
             var logger = mocks.Create<ILogger>().Object;
             var task = new NDependTask(executor, fileSystem, logger);
             task.Executable = "ndepend-app.exe";
@@ -292,25 +292,25 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Tasks
         [Test]
         public void CanOverrideBaseDirectory()
         {
-            var workingDir = "somewhere-else\\NDependResults";
+            var workingDir = System.IO.Path.Combine("somewhere-else", "NDependResults");
             var result = GenerateResultMock();
-            var executor = GenerateExecutorMock("somewhere-else\\NDepend.Console", "somewhere-else\\NDependResults /OutDir somewhere-else\\NDependResults", "somewhere-else", 600000);
+            var executor = GenerateExecutorMock(System.IO.Path.Combine("somewhere-else", "NDepend.Console"), workingDir + " /OutDir " + workingDir, "somewhere-else", 600000);
             var fileSystem = mocks.Create<IFileSystem>(MockBehavior.Strict).Object;
             MockSequence sequence = new MockSequence();
             Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.DirectoryExists(workingDir)).Returns(true).Verifiable();
             Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.GetFilesInDirectory(workingDir)).Returns(new string[0]).Verifiable();
-            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.FileExists("somewhere-else\\NDependResults\\ReportResources.xml")).Returns(false).Verifiable();
+            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.FileExists(System.IO.Path.Combine("somewhere-else", "NDependResults", "ReportResources.xml"))).Returns(false).Verifiable();
             Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.DirectoryExists(workingDir)).Returns(true).Verifiable();
             Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.GetFilesInDirectory(workingDir)).Returns(new string[] {
-                "somewhere-else\\NDependResults\\file1.txt",
-                "somewhere-else\\NDependResults\\file2.xml"
+                System.IO.Path.Combine("somewhere-else", "NDependResults", "file1.txt"),
+                System.IO.Path.Combine("somewhere-else", "NDependResults", "file2.xml")
             }).Verifiable();
-            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.DirectoryExists("artefactDir\\1\\NDepend")).Returns(true).Verifiable();
-            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.FileExists("somewhere-else\\NDependResults\\file1.txt")).Returns(true).Verifiable();
-            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.Copy("somewhere-else\\NDependResults\\file1.txt", "artefactDir\\1\\NDepend\\file1.txt")).Verifiable();
-            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.FileExists("somewhere-else\\NDependResults\\file2.xml")).Returns(true).Verifiable();
-            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.Copy("somewhere-else\\NDependResults\\file2.xml", "artefactDir\\1\\NDepend\\file2.xml")).Verifiable();
-            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.GenerateTaskResultFromFile("somewhere-else\\NDependResults\\file2.xml")).Returns(mocks.Create<ITaskResult>().Object).Verifiable();
+            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.DirectoryExists(System.IO.Path.Combine("artefactDir", "1", "NDepend"))).Returns(true).Verifiable();
+            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.FileExists(System.IO.Path.Combine("somewhere-else", "NDependResults", "file1.txt"))).Returns(true).Verifiable();
+            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.Copy(System.IO.Path.Combine("somewhere-else", "NDependResults", "file1.txt"), System.IO.Path.Combine("artefactDir", "1", "NDepend", "file1.txt"))).Verifiable();
+            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.FileExists(System.IO.Path.Combine("somewhere-else", "NDependResults", "file2.xml"))).Returns(true).Verifiable();
+            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.Copy(System.IO.Path.Combine("somewhere-else", "NDependResults", "file2.xml"), System.IO.Path.Combine("artefactDir", "1", "NDepend", "file2.xml"))).Verifiable();
+            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.GenerateTaskResultFromFile(System.IO.Path.Combine("somewhere-else", "NDependResults", "file2.xml"))).Returns(mocks.Create<ITaskResult>().Object).Verifiable();
             var logger = mocks.Create<ILogger>().Object;
             var task = new NDependTask(executor, fileSystem, logger);
             task.BaseDirectory = "somewhere-else";
@@ -324,27 +324,28 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Tasks
         [Test]
         public void AllApplicationArgsAreSet()
         {
-            var workingDir = "workingDir\\out-dir";
+            var workingDir = System.IO.Path.Combine("workingDir", "out-dir");
             var result = GenerateResultMock();
-            var executor = GenerateExecutorMock("workingDir\\NDepend.Console",
-                "workingDir\\test.project /Silent /EmitVisualNDependBinXml  /InDirs workingDir\\dir1 workingDir\\dir2 /OutDir workingDir\\out-dir /XslForReport  workingDir\\report.xslt", 
+            var executor = GenerateExecutorMock(System.IO.Path.Combine("workingDir", "NDepend.Console"),
+                System.IO.Path.Combine("workingDir", "test.project") + " /Silent /EmitVisualNDependBinXml  /InDirs " + System.IO.Path.Combine("workingDir", "dir1") + " " + System.IO.Path.Combine("workingDir", "dir2") + 
+                " /OutDir " + workingDir + " /XslForReport  " + System.IO.Path.Combine("workingDir", "report.xslt"), 
                 "workingDir", 600000);
             var fileSystem = mocks.Create<IFileSystem>(MockBehavior.Strict).Object;
             MockSequence sequence = new MockSequence();
             Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.DirectoryExists(workingDir)).Returns(true).Verifiable();
             Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.GetFilesInDirectory(workingDir)).Returns(new string[0]).Verifiable();
-            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.FileExists("workingDir\\out-dir\\ReportResources.xml")).Returns(false).Verifiable();
+            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.FileExists(System.IO.Path.Combine("workingDir", "out-dir", "ReportResources.xml"))).Returns(false).Verifiable();
             Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.DirectoryExists(workingDir)).Returns(true).Verifiable();
             Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.GetFilesInDirectory(workingDir)).Returns(new string[] {
-                "workingDir\\out-dir\\file1.txt",
-                "workingDir\\out-dir\\file2.xml"
+                System.IO.Path.Combine("workingDir", "out-dir", "file1.txt"),
+                System.IO.Path.Combine("workingDir", "out-dir", "file2.xml")
             }).Verifiable();
-            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.DirectoryExists("artefactDir\\1\\NDepend")).Returns(true).Verifiable();
-            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.FileExists("workingDir\\out-dir\\file1.txt")).Returns(true).Verifiable();
-            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.Copy("workingDir\\out-dir\\file1.txt", "artefactDir\\1\\NDepend\\file1.txt")).Verifiable();
-            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.FileExists("workingDir\\out-dir\\file2.xml")).Returns(true).Verifiable();
-            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.Copy("workingDir\\out-dir\\file2.xml", "artefactDir\\1\\NDepend\\file2.xml")).Verifiable();
-            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.GenerateTaskResultFromFile("workingDir\\out-dir\\file2.xml")).Returns(mocks.Create<ITaskResult>().Object).Verifiable();
+            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.DirectoryExists(System.IO.Path.Combine("artefactDir", "1", "NDepend"))).Returns(true).Verifiable();
+            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.FileExists(System.IO.Path.Combine("workingDir", "out-dir", "file1.txt"))).Returns(true).Verifiable();
+            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.Copy(System.IO.Path.Combine("workingDir", "out-dir", "file1.txt"), System.IO.Path.Combine("artefactDir", "1", "NDepend", "file1.txt"))).Verifiable();
+            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.FileExists(System.IO.Path.Combine("workingDir", "out-dir", "file2.xml"))).Returns(true).Verifiable();
+            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.Copy(System.IO.Path.Combine("workingDir", "out-dir", "file2.xml"), System.IO.Path.Combine("artefactDir", "1", "NDepend", "file2.xml"))).Verifiable();
+            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.GenerateTaskResultFromFile(System.IO.Path.Combine("workingDir", "out-dir", "file2.xml"))).Returns(mocks.Create<ITaskResult>().Object).Verifiable();
             var logger = mocks.Create<ILogger>().Object;
             var task = new NDependTask(executor, fileSystem, logger);
             task.ProjectFile = "test.project";
@@ -367,30 +368,30 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Tasks
         [Test]
         public void RunningOnExistingDirectoryChecksFilesAndCopiesWhenNewer()
         {
-            var workingDir = "workingDir\\NDependResults";
+            var workingDir = System.IO.Path.Combine("workingDir", "NDependResults");
             var result = GenerateResultMock();
-            var executor = GenerateExecutorMock("workingDir\\NDepend.Console", "workingDir\\NDependResults /OutDir workingDir\\NDependResults", "workingDir", 600000);
+            var executor = GenerateExecutorMock(System.IO.Path.Combine("workingDir", "NDepend.Console"), workingDir + " /OutDir " + workingDir, "workingDir", 600000);
             var fileSystem = mocks.Create<IFileSystem>(MockBehavior.Strict).Object;
             MockSequence sequence = new MockSequence();
             Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.DirectoryExists(workingDir)).Returns(true).Verifiable();
             Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.GetFilesInDirectory(workingDir)).Returns(new string[] {
-                "workingDir\\NDependResults\\file1.txt",
-                "workingDir\\NDependResults\\file2.xml"
+                System.IO.Path.Combine("workingDir", "NDependResults", "file1.txt"),
+                System.IO.Path.Combine("workingDir", "NDependResults", "file2.xml")
             }).Verifiable();
             var baseTime = DateTime.Now;
-            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.GetLastWriteTime("workingDir\\NDependResults\\file1.txt")).Returns(baseTime).Verifiable();
-            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.GetLastWriteTime("workingDir\\NDependResults\\file2.xml")).Returns(baseTime).Verifiable();
-            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.FileExists("workingDir\\NDependResults\\ReportResources.xml")).Returns(false).Verifiable();
+            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.GetLastWriteTime(System.IO.Path.Combine("workingDir", "NDependResults", "file1.txt"))).Returns(baseTime).Verifiable();
+            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.GetLastWriteTime(System.IO.Path.Combine("workingDir", "NDependResults", "file2.xml"))).Returns(baseTime).Verifiable();
+            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.FileExists(System.IO.Path.Combine("workingDir", "NDependResults", "ReportResources.xml"))).Returns(false).Verifiable();
             Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.DirectoryExists(workingDir)).Returns(true).Verifiable();
             Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.GetFilesInDirectory(workingDir)).Returns(new string[] {
-                "workingDir\\NDependResults\\file1.txt",
-                "workingDir\\NDependResults\\file2.xml"
+                System.IO.Path.Combine("workingDir", "NDependResults", "file1.txt"),
+                System.IO.Path.Combine("workingDir", "NDependResults", "file2.xml")
             }).Verifiable();
-            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.GetLastWriteTime("workingDir\\NDependResults\\file1.txt")).Returns(baseTime.AddMinutes(1)).Verifiable();
-            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.GetLastWriteTime("workingDir\\NDependResults\\file2.xml")).Returns(baseTime).Verifiable();
-            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.DirectoryExists("artefactDir\\1\\NDepend")).Returns(true).Verifiable();
-            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.FileExists("workingDir\\NDependResults\\file1.txt")).Returns(true).Verifiable();
-            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.Copy("workingDir\\NDependResults\\file1.txt", "artefactDir\\1\\NDepend\\file1.txt")).Verifiable();
+            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.GetLastWriteTime(System.IO.Path.Combine("workingDir", "NDependResults", "file1.txt"))).Returns(baseTime.AddMinutes(1)).Verifiable();
+            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.GetLastWriteTime(System.IO.Path.Combine("workingDir", "NDependResults", "file2.xml"))).Returns(baseTime).Verifiable();
+            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.DirectoryExists(System.IO.Path.Combine("artefactDir", "1", "NDepend"))).Returns(true).Verifiable();
+            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.FileExists(System.IO.Path.Combine("workingDir", "NDependResults", "file1.txt"))).Returns(true).Verifiable();
+            Mock.Get(fileSystem).InSequence(sequence).Setup(_fileSystem => _fileSystem.Copy(System.IO.Path.Combine("workingDir", "NDependResults", "file1.txt"), System.IO.Path.Combine("artefactDir", "1", "NDepend", "file1.txt"))).Verifiable();
             var logger = mocks.Create<ILogger>().Object;
             var task = new NDependTask(executor, fileSystem, logger);
 
@@ -425,7 +426,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Tasks
             Mock.Get(result).SetupGet(_result => _result.IntegrationProperties).Returns(new Dictionary<string, string>());
             Mock.Get(result).SetupGet(_result => _result.Label).Returns("1");
             Mock.Get(result).Setup(_result => _result.AddTaskResult(It.IsAny<ITaskResult>())).Verifiable();
-            Mock.Get(result).Setup(_result => _result.BaseFromArtifactsDirectory("1")).Returns(string.Concat(artefactDir, "\\1"));
+            Mock.Get(result).Setup(_result => _result.BaseFromArtifactsDirectory("1")).Returns(System.IO.Path.Combine(artefactDir, "1"));
             return result;
         }
 

--- a/project/UnitTests/Core/Tasks/PowerShellTaskTest.cs
+++ b/project/UnitTests/Core/Tasks/PowerShellTaskTest.cs
@@ -79,7 +79,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Tasks
                 @"SOFTWARE\Microsoft\PowerShell\2\PowerShellEngine",
                 @"ApplicationBase")).Returns(@"C:\Windows\System32\WindowsPowerShell\v1.0").Verifiable();
 
-            Assert.AreEqual(@"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe", task.Executable);
+            Assert.AreEqual(System.IO.Path.Combine(@"C:\Windows\System32\WindowsPowerShell\v1.0", "powershell.exe"), task.Executable);
             Assert.AreEqual(@"myScript.ps1", task.Script);
             Assert.AreEqual(PowerShellTask.DefaultScriptsDirectory, task.ConfiguredScriptsDirectory);
             Assert.AreEqual(PowerShellTask.DefaultBuildTimeOut, task.BuildTimeoutSeconds);
@@ -95,7 +95,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Tasks
             PowerShellTask task = new PowerShellTask((IRegistry)mockRegistry2.Object, (ProcessExecutor)mockProcessExecutor.Object);
             mockRegistry2.Setup(registry => registry.GetLocalMachineSubKeyValue(PowerShellTask.regkeypowershell2, PowerShellTask.regkeyholder)).Returns(() => null).Verifiable();
             mockRegistry2.Setup(registry => registry.GetLocalMachineSubKeyValue(PowerShellTask.regkeypowershell1, PowerShellTask.regkeyholder)).Returns(POWERSHELL1_PATH).Verifiable();
-            Assert.AreEqual(POWERSHELL1_PATH + "\\powershell.exe", task.Executable);
+            Assert.AreEqual(System.IO.Path.Combine(POWERSHELL1_PATH, "powershell.exe"), task.Executable);
             mockRegistry2.Verify();
             mockProcessExecutor.Verify();
         }
@@ -109,7 +109,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Tasks
             PowerShellTask task = new PowerShellTask((IRegistry)mockRegistry2.Object, (ProcessExecutor)mockProcessExecutor.Object);
             mockRegistry2.Setup(registry => registry.GetLocalMachineSubKeyValue(PowerShellTask.regkeypowershell2, PowerShellTask.regkeyholder)).Returns(() => null).Verifiable();
             mockRegistry2.Setup(registry => registry.GetLocalMachineSubKeyValue(PowerShellTask.regkeypowershell1, PowerShellTask.regkeyholder)).Returns(() => null).Verifiable();
-            Assert.AreEqual(POWERSHELL1_PATH + "\\powershell.exe", task.Executable);
+            Assert.AreEqual(System.IO.Path.Combine(POWERSHELL1_PATH, "powershell.exe"), task.Executable);
             mockRegistry2.Verify();
             mockProcessExecutor.Verify();
         }  
@@ -121,7 +121,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Tasks
 
             PowerShellTask task = new PowerShellTask((IRegistry)mockRegistry2.Object, (ProcessExecutor)mockProcessExecutor.Object);
             mockRegistry2.Setup(registry => registry.GetLocalMachineSubKeyValue(PowerShellTask.regkeypowershell2,PowerShellTask.regkeyholder)).Returns(POWERSHELL2_PATH).Verifiable();
-            Assert.AreEqual(POWERSHELL2_PATH + "\\powershell.exe", task.Executable);
+            Assert.AreEqual(System.IO.Path.Combine(POWERSHELL2_PATH, "powershell.exe"), task.Executable);
             mockRegistry2.Verify();
             mockProcessExecutor.Verify();
         }           
@@ -193,14 +193,16 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Tasks
             mockProcessExecutor.Setup(executor => executor.Execute(It.IsAny<ProcessInfo>())).
                 Callback<ProcessInfo>(processInfo => info = processInfo).Returns(processResult).Verifiable();
 
+            string path = Platform.IsWindows ? @"D:\CruiseControl" : @"/CruiseControl";
+            
             mytask.Executable = POWERSHELL_PATH;
             mytask.Script = "MyScript.ps1";
-            mytask.ConfiguredScriptsDirectory = @"D:\CruiseControl";
+            mytask.ConfiguredScriptsDirectory = path;
 
-            IIntegrationResult result = Integration("myProject", @"D:\CruiseControl", "myArtifactDirectory");
+            IIntegrationResult result = Integration("myProject", path, "myArtifactDirectory");
             mytask.Run(result);
 
-            Assert.AreEqual(@"D:\CruiseControl", info.WorkingDirectory);
+            Assert.AreEqual(path, info.WorkingDirectory);
 
             Assert.AreEqual(IntegrationStatus.Failure, result.Status);
             CustomAssertion.AssertMatches(@"(\.|\n)*is not recognized as a cmdlet", result.TaskOutput);

--- a/project/UnitTests/Core/Util/RegistryTest.cs
+++ b/project/UnitTests/Core/Util/RegistryTest.cs
@@ -11,6 +11,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Util
 		private const string VALID_REGISTRY_PATH = @"SOFTWARE\Microsoft\Windows\CurrentVersion";
 
 		[Test]
+        [Platform(Exclude = "Mono", Reason = "No real registry under Linux")]
 		public void GetLocalMachineSubKeyValue()
 		{
 			string programFilesPath = new Registry().GetLocalMachineSubKeyValue(VALID_REGISTRY_PATH, "ProgramFilesPath");

--- a/project/UnitTests/Core/Util/SystemIoFileSystemTest.cs
+++ b/project/UnitTests/Core/Util/SystemIoFileSystemTest.cs
@@ -165,6 +165,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Util
                     File.WriteAllText(file, "Some data");
                 }
                 var results = new SystemIoFileSystem().GetFilesInDirectory(tempPath);
+                Array.Sort(results);
                 CollectionAssert.AreEqual(files, results);
             }
             finally
@@ -201,6 +202,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Util
                 File.WriteAllText(Path.Combine(subDir, "file4.txt"), "Some data");
 
                 var results = new SystemIoFileSystem().GetFilesInDirectory(tempPath, false);
+                Array.Sort(results);
                 CollectionAssert.AreEqual(files, results);
             }
             finally
@@ -237,6 +239,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Util
                 File.WriteAllText(subFile, "Some data");
 
                 var results = new SystemIoFileSystem().GetFilesInDirectory(tempPath, true);
+                Array.Sort(results);
                 CollectionAssert.AreEqual(files.Concat(new[] { subFile}), results);
             }
             finally

--- a/project/UnitTests/Core/Util/WildCardPathTest.cs
+++ b/project/UnitTests/Core/Util/WildCardPathTest.cs
@@ -101,7 +101,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Util
         [Test]
         public void StringWithWildcardsInPathShouldReturnOneTxtFileInsideRootLevel()
         {
-            WildCardPath wildCard = new WildCardPath(Path.Combine(tempFolderFullPath, @"RootLevel\**\FileA.txt"));
+            WildCardPath wildCard = new WildCardPath(Path.Combine(tempFolderFullPath, "RootLevel", "**", "FileA.txt"));
 
             FileInfo[] fileMatches = wildCard.GetFiles();
 
@@ -111,7 +111,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Util
         [Test]
         public void StringWithWildcardsInPathShouldGetAllTxtFilesInsideRootLevel()
         {
-            WildCardPath wildCard = new WildCardPath(Path.Combine(tempFolderFullPath, @"RootLevel\**\*.txt"));
+            WildCardPath wildCard = new WildCardPath(Path.Combine(tempFolderFullPath, "RootLevel", "**", "*.txt"));
 
             FileInfo[] fileMatches = wildCard.GetFiles();
 
@@ -121,7 +121,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Util
         [Test]
         public void StringWithWildcardsInPathShouldUseWildcardsFollowedByFolderNameSegment()
         {
-            WildCardPath wildCard = new WildCardPath(Path.Combine(tempFolderFullPath, @"RootLevel\**\ThirdLevelA\*.txt"));
+            WildCardPath wildCard = new WildCardPath(Path.Combine(new string [] {tempFolderFullPath, "RootLevel", "**", "ThirdLevelA", "*.txt"}));
             FileInfo[] fileMatches = wildCard.GetFiles();
 
             Assert.AreEqual(3, fileMatches.Length);
@@ -130,7 +130,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Util
         [Test]
         public void StringWithWildcardsInPathShouldUseWildcardsInTwoFolderSegments()
         {
-            WildCardPath wildCard = new WildCardPath(Path.Combine(tempFolderFullPath, @"RootLevel\**\SecondLevelA\**\*.txt"));
+            WildCardPath wildCard = new WildCardPath(Path.Combine(new string [] {tempFolderFullPath, "RootLevel", "**", "SecondLevelA", "**", "*.txt"}));
 
             FileInfo[] fileMatches = wildCard.GetFiles();
 
@@ -140,7 +140,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Util
         [Test]
         public void StringWithWildcardsInPathShouldUseFolderWildcardsAndSimpleWildcardForAFolderName()
         {
-            WildCardPath wildCard = new WildCardPath(Path.Combine(tempFolderFullPath, @"RootLevel\**\SecondLevelA\Thir*\*.txt"));
+            WildCardPath wildCard = new WildCardPath(Path.Combine(new string [] {tempFolderFullPath, "RootLevel", "**", "SecondLevelA", "Thir*", "*.txt"}));
 
             FileInfo[] fileMatches = wildCard.GetFiles();
 

--- a/project/UnitTests/CustomAssertion.cs
+++ b/project/UnitTests/CustomAssertion.cs
@@ -100,7 +100,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests
 
 		public static void AssertEqualArrays(Array expected, Array actual)
 		{
-			Assert.AreEqual(actual.Length, expected.Length, "Arrays should have same length");
+			Assert.AreEqual(expected.Length, actual.Length, "Arrays should have same length");
 
 			for (int i = 0; i < expected.Length; i++)
 			{

--- a/project/UnitTests/IntegrationTests/PublisherTests.cs
+++ b/project/UnitTests/IntegrationTests/PublisherTests.cs
@@ -22,7 +22,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.IntegrationTests
             const string ProjectName1 = "PackageTest01";
 
             string IntegrationFolder = System.IO.Path.Combine("scenarioTests", ProjectName1);
-            string CCNetConfigFile = System.IO.Path.Combine("IntegrationScenarios", "PackagePublisherTest01.xml");
+            string CCNetConfigFile = System.IO.Path.Combine("IntegrationScenarios", "PackagePublisherTest01" + (Platform.IsWindows ? "" : "_linux") + ".xml");
             string ProjectStateFile = new System.IO.FileInfo(ProjectName1 + ".state").FullName;
 
             IntegrationCompleted = new System.Collections.Generic.Dictionary<string, bool>();
@@ -125,7 +125,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.IntegrationTests
             const string ProjectName1 = "PackageTest02";
 
             string IntegrationFolder = System.IO.Path.Combine("scenarioTests", ProjectName1);
-            string CCNetConfigFile = System.IO.Path.Combine("IntegrationScenarios", "PackagePublisherTest02.xml");
+            string CCNetConfigFile = System.IO.Path.Combine("IntegrationScenarios", "PackagePublisherTest02" + (Platform.IsWindows ? "" : "_linux") + ".xml");
             string ProjectStateFile = new System.IO.FileInfo(ProjectName1 + ".state").FullName;
 
             IntegrationCompleted = new System.Collections.Generic.Dictionary<string, bool>();
@@ -230,7 +230,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.IntegrationTests
             const string ProjectName1 = "PackageTest03";
 
             string IntegrationFolder = System.IO.Path.Combine("scenarioTests", ProjectName1);
-            string CCNetConfigFile = System.IO.Path.Combine("IntegrationScenarios", "PackagePublisherTest03.xml");
+            string CCNetConfigFile = System.IO.Path.Combine("IntegrationScenarios", "PackagePublisherTest03" + (Platform.IsWindows ? "" : "_linux") + ".xml");
             string ProjectStateFile = new System.IO.FileInfo(ProjectName1 + ".state").FullName;
 
             IntegrationCompleted = new System.Collections.Generic.Dictionary<string, bool>();

--- a/project/UnitTests/IntegrationTests/PublisherTests.cs
+++ b/project/UnitTests/IntegrationTests/PublisherTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using NUnit.Framework;
 using ThoughtWorks.CruiseControl.Core;
 using CCNet = ThoughtWorks.CruiseControl;
@@ -106,15 +107,16 @@ namespace ThoughtWorks.CruiseControl.UnitTests.IntegrationTests
             Assert.IsTrue(System.IO.File.Exists(ExpectedZipFile),"zip package not found at expected location");
 
             ICSharpCode.SharpZipLib.Zip.ZipFile zf = new ICSharpCode.SharpZipLib.Zip.ZipFile(ExpectedZipFile);
-            string expectedFiles = string.Empty;
+            List<string> actualFiles = new List<string>();
 
             foreach (ICSharpCode.SharpZipLib.Zip.ZipEntry ze in zf)
             {
                 System.Diagnostics.Debug.WriteLine(ze.Name);
-                expectedFiles += ze.Name;
+                actualFiles.Add(ze.Name);
             }
+            actualFiles.Sort();
 
-            Assert.AreEqual("a.txtb.txt", expectedFiles);
+            Assert.AreEqual("a.txtb.txt", String.Join("", actualFiles));
 
         }
 
@@ -208,15 +210,16 @@ namespace ThoughtWorks.CruiseControl.UnitTests.IntegrationTests
             Assert.IsTrue(System.IO.File.Exists(ExpectedZipFile), "zip package not found at expected location");
 
             ICSharpCode.SharpZipLib.Zip.ZipFile zf = new ICSharpCode.SharpZipLib.Zip.ZipFile(ExpectedZipFile);
-            string expectedFiles = string.Empty;
+            List<string> actualFiles = new List<string>();
 
             foreach (ICSharpCode.SharpZipLib.Zip.ZipEntry ze in zf)
             {
                 System.Diagnostics.Debug.WriteLine(ze.Name);
-                expectedFiles += ze.Name;
+                actualFiles.Add(ze.Name);
             }
+            actualFiles.Sort();
 
-            Assert.AreEqual(@"Info/Sub1/a.txtInfo/Sub1/b.txt", expectedFiles);
+            Assert.AreEqual(@"Info/Sub1/a.txtInfo/Sub1/b.txt", String.Join("", actualFiles));
 
         }
 

--- a/project/UnitTests/Remote/ProjectStatusTests.cs
+++ b/project/UnitTests/Remote/ProjectStatusTests.cs
@@ -118,7 +118,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Remote
 
             serializer.Serialize(writer, projectStatus, nmsp);
 
-            Assert.AreEqual("<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n" +
+            Assert.AreEqual("<?xml version=\"1.0\" encoding=\"utf-16\"?>" + Environment.NewLine +
                             "<projectStatus " +
                             "showForceBuildButton=\"true\" " +
                             "showStartStopButton=\"true\" " +
@@ -128,9 +128,9 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Remote
                             "queuePriority=\"0\" " +
                             "lastBuildDate=\"0001-01-01T00:00:00\" " +
                             "nextBuildTime=\"0001-01-01T00:00:00\"" +
-                            ">\r\n" +
-                            "  <activity type=\"Sleeping\" />\r\n" +
-                            "  <parameters />\r\n" +
+                            ">" + Environment.NewLine +
+                            "  <activity type=\"Sleeping\" />" + Environment.NewLine +
+                            "  <parameters />" + Environment.NewLine +
                             "</projectStatus>",
                             writer.ToString());
         }
@@ -150,7 +150,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Remote
 
             serializer.Serialize(writer, projectStatus, nmsp);
 
-            Assert.AreEqual("<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n" +
+            Assert.AreEqual("<?xml version=\"1.0\" encoding=\"utf-16\"?>" + Environment.NewLine +
                             "<projectStatus " +
                             "showForceBuildButton=\"true\" " +
                             "showStartStopButton=\"true\" " +
@@ -161,9 +161,9 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Remote
                             "queuePriority=\"0\" " +
                             "lastBuildDate=\"" + lastBuildDate.ToString("yyyy-MM-ddTHH:mm:ss.FFFFFFF") + "\" " +
                             "nextBuildTime=\"0001-01-01T00:00:00\"" +
-                            ">\r\n" +
-                            "  <activity type=\"Sleeping\" />\r\n" +
-                            "  <parameters />\r\n" +
+                            ">" + Environment.NewLine +
+                            "  <activity type=\"Sleeping\" />" + Environment.NewLine +
+                            "  <parameters />" + Environment.NewLine +
                             "</projectStatus>",
                             writer.ToString());
         }
@@ -198,7 +198,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Remote
 
             serializer.Serialize(writer, projectStatus, nmsp);
 
-            Assert.AreEqual("<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n" +
+            Assert.AreEqual("<?xml version=\"1.0\" encoding=\"utf-16\"?>" + Environment.NewLine +
                             "<projectStatus " +
                             "stage=\"" + buildStage + "\" " +
                             "showForceBuildButton=\"true\" " +
@@ -215,9 +215,9 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Remote
                             "lastBuildLabel=\"" + lastBuildLabel + "\" " +
                             "lastSuccessfulBuildLabel=\"" + lastSuccessfulBuildLabel + "\" " +
                             "nextBuildTime=\"" + nextBuildTime.ToString("yyyy-MM-ddTHH:mm:ss.FFFFFFF") + "\"" +
-                            ">\r\n" +
-                            "  <activity type=\"" + activity.ToString() + "\" />\r\n" +
-                            "  <parameters />\r\n" +
+                            ">" + Environment.NewLine +
+                            "  <activity type=\"" + activity.ToString() + "\" />" + Environment.NewLine +
+                            "  <parameters />" + Environment.NewLine +
                             "</projectStatus>",
                             writer.ToString());
         }
@@ -263,7 +263,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Remote
                 string streamedParameter = parameterWriter.ToString();
                 streamedParameter = Regex.Replace(streamedParameter, parameter.GetType().Name, "parameter d3p1:type=\"" + parameter.GetType().Name + "\"", RegexOptions.IgnoreCase);
                 streamedParameter = Regex.Replace(streamedParameter, "/>", "xmlns:d3p1=\"http://www.w3.org/2001/XMLSchema-instance\" />", RegexOptions.IgnoreCase);
-                streamedParameters += "    " + streamedParameter + "\r\n";
+                streamedParameters += "    " + streamedParameter + "" + Environment.NewLine;
             }
 
             XmlSerializerNamespaces nmsp = new XmlSerializerNamespaces();
@@ -274,7 +274,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Remote
 
             serializer.Serialize(writer, projectStatus, nmsp);
 
-            Assert.AreEqual("<?xml version=\"1.0\" encoding=\"utf-16\"?>\r\n" +
+            Assert.AreEqual("<?xml version=\"1.0\" encoding=\"utf-16\"?>" + Environment.NewLine +
                             "<projectStatus " +
                             "stage=\"" + buildStage + "\" " +
                             "showForceBuildButton=\"true\" " +
@@ -291,11 +291,11 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Remote
                             "lastBuildLabel=\"" + lastBuildLabel + "\" " +
                             "lastSuccessfulBuildLabel=\"" + lastSuccessfulBuildLabel + "\" " +
                             "nextBuildTime=\"" + nextBuildTime.ToString("yyyy-MM-ddTHH:mm:ss.FFFFFFF") + "\"" +
-                            ">\r\n" +
-                            "  <activity type=\"" + activity.ToString() + "\" />\r\n" +
-                            "  <parameters>\r\n" + 
+                            ">" + Environment.NewLine +
+                            "  <activity type=\"" + activity.ToString() + "\" />" + Environment.NewLine +
+                            "  <parameters>" + Environment.NewLine + 
                             streamedParameters +
-                            "  </parameters>\r\n" +
+                            "  </parameters>" + Environment.NewLine +
                             "</projectStatus>",
                             writer.ToString());
         }

--- a/project/UnitTests/UnitTestUtils/Platform.cs
+++ b/project/UnitTests/UnitTestUtils/Platform.cs
@@ -1,0 +1,24 @@
+using System;
+using System.IO;
+
+namespace ThoughtWorks.CruiseControl.UnitTests
+{
+    public class Platform 
+    {
+        public static bool IsMono
+        {
+            get
+            {
+                return Type.GetType("Mono.Runtime") != null;
+            }
+        }
+        
+        public static bool IsWindows
+        {
+            get
+            {
+                return Path.DirectorySeparatorChar == '\\';
+            }
+        }
+    }
+}

--- a/project/UnitTests/UnitTests.csproj
+++ b/project/UnitTests/UnitTests.csproj
@@ -1060,6 +1060,9 @@
     <Compile Include="UnitTestUtils\Mockery.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="UnitTestUtils\Platform.cs">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="UnitTestUtils\ResourceUtil.cs">
       <SubType>Code</SubType>
     </Compile>

--- a/project/UnitTests/WebDashboard/MVC/View/LazilyInitialisingVelocityTransformerTest.cs
+++ b/project/UnitTests/WebDashboard/MVC/View/LazilyInitialisingVelocityTransformerTest.cs
@@ -31,7 +31,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.WebDashboard.MVC.View
             viewTransformer = new LazilyInitialisingVelocityTransformer((IPhysicalApplicationPathProvider)pathMapperMock.Object,
                 (IDashboardConfiguration)configurationMock.Object);
 
-			Assert.AreEqual("foo is bar", viewTransformer.Transform("testTransform.vm", contextContents));
+			Assert.AreEqual("foo is bar", viewTransformer.Transform("TestTransform.vm", contextContents));
 		}
 	}
 }

--- a/project/UnitTests/WebDashboard/Plugins/ProjectReport/ProjectFileDownloadTests.cs
+++ b/project/UnitTests/WebDashboard/Plugins/ProjectReport/ProjectFileDownloadTests.cs
@@ -42,7 +42,7 @@
             Mock.Get(cruiseRequest).Setup(_cruiseRequest => _cruiseRequest.RetrieveSessionToken()).Returns((string)null);
             Mock.Get(request).Setup(_request => _request.GetText("file")).Returns(fileName);
             Mock.Get(request).Setup(_request => _request.GetText("label")).Returns(label);
-            Mock.Get(farmService).Setup(_farmService => _farmService.RetrieveFileTransfer(projectSpec, label + "\\" + fileName, null)).Returns(transfer);
+            Mock.Get(farmService).Setup(_farmService => _farmService.RetrieveFileTransfer(projectSpec, System.IO.Path.Combine(label, fileName), null)).Returns(transfer);
 
             var response = action.Execute(cruiseRequest);
 

--- a/project/UnitTests/WebDashboard/ServerConnection/ServerAggregatingCruiseManagerWrapperTest.cs
+++ b/project/UnitTests/WebDashboard/ServerConnection/ServerAggregatingCruiseManagerWrapperTest.cs
@@ -105,7 +105,7 @@ namespace ThoughtWorks.CruiseControl.UnitTests.WebDashboard.ServerConnection
 		[Test]
 		public void ReturnsCorrectLogFromCorrectProjectOnCorrectServer()
 		{
-            string buildLog = "content\r\nlogdata";
+            string buildLog = "content" + Environment.NewLine + "logdata";
             MockRepository mocks = new MockRepository(MockBehavior.Default);
             ServerAggregatingCruiseManagerWrapper serverWrapper = InitialiseServerWrapper(mocks,
                 delegate(CruiseServerClientBase manager)

--- a/project/UnitTests/resources/IntegrationScenarios/PackagePublisherTest01_linux.xml
+++ b/project/UnitTests/resources/IntegrationScenarios/PackagePublisherTest01_linux.xml
@@ -1,0 +1,22 @@
+﻿<cruisecontrol xmlns:cb="urn:ccnet.config.builder">
+
+  
+  <project name="PackageTest01" workingDirectory="Packaging01">
+    <triggers />
+    
+    <tasks>
+      <package name="TestPackage" always="true">
+        <packageList>
+          <packageFile sourceFile="Info/Sub1/*.txt" flatten="true"/>
+        </packageList>
+      </package>
+
+    </tasks>
+    
+    <publishers>
+      <xmllogger />
+    </publishers>
+  </project>
+  
+  
+</cruisecontrol>

--- a/project/UnitTests/resources/IntegrationScenarios/PackagePublisherTest02_linux.xml
+++ b/project/UnitTests/resources/IntegrationScenarios/PackagePublisherTest02_linux.xml
@@ -1,0 +1,22 @@
+﻿<cruisecontrol xmlns:cb="urn:ccnet.config.builder">
+
+  
+  <project name="PackageTest02" workingDirectory="Packaging02">
+    <triggers />
+    
+    <tasks>
+      <package name="TestPackage" always="true">
+        <packageList>
+          <packageFile sourceFile="Info/Sub1/*.txt" flatten="false"/>
+        </packageList>
+      </package>
+
+    </tasks>
+    
+    <publishers>
+      <xmllogger />
+    </publishers>
+  </project>
+  
+  
+</cruisecontrol>

--- a/project/UnitTests/resources/IntegrationScenarios/PackagePublisherTest03_linux.xml
+++ b/project/UnitTests/resources/IntegrationScenarios/PackagePublisherTest03_linux.xml
@@ -1,0 +1,28 @@
+﻿<cruisecontrol xmlns:cb="urn:ccnet.config.builder">
+
+
+  <project name="PackageTest03"
+           workingDirectory="Packaging03">
+    <triggers />
+
+    <tasks>
+      <package always="true" >
+        <name>Project-package.zip</name>
+        <packageList>
+          <packageFolder includeSubFolders="true" >
+            <sourceFolder>some/directories/deeper/_PublishedWebsites/MyProject</sourceFolder>
+            <flatten>false</flatten>
+            <targetFolder>MegaWebSite</targetFolder> 
+            <fileFilter>*.*</fileFilter>
+          </packageFolder>
+        </packageList>
+      </package>
+    </tasks>
+
+    <publishers>
+      <xmllogger />
+    </publishers>
+  </project>
+
+
+</cruisecontrol>


### PR DESCRIPTION
A few changes, where changes are grouped by commits to show what was required to get to the lowest possible failures.
With this (and changes in the project itself), I'm down to those: 

     [exec] 1) Failed : ThoughtWorks.CruiseControl.UnitTests.Core.Config.ValidatingLoaderTest.ShouldBeAbleToLoadXmlWithDTD
     [exec]   p1 should have been found
     [exec]   Expected: not null
     [exec]   But was:  null
     [exec]   at ThoughtWorks.CruiseControl.UnitTests.Core.Config.ValidatingLoaderTest.ShouldBeAbleToLoadXmlWithDTD () [0x00000] in <dac301ed37f1469e88502226d4a9082d>:0
     [exec]
     [exec] 2) Failed : ThoughtWorks.CruiseControl.UnitTests.Core.Publishers.EmailPublisherTest.EmailMessageWithDetails
     [exec]   message does not contain modifications: <html><head><style>body, table, form, input, td, th, p, textarea, select
     [exec] {
     [exec]  font-family: verdana, helvetica, arial;
     [exec]  font-size: 11px;
     [exec] }
     [exec]
     [exec] a:hover { color:#FC0; }
     [exec]
     [exec] .main-panel { color:#FC0; }
     [exec]
     [exec] .link { color:#FFF; text-decoration:none; }
     [exec] .link-failed { color:#F30; text-decoration:none; }
     [exec] .buildresults-header { color: #FFF; font-weight: bold; }
     [exec] .buildresults-data { color: #9F3; }
     [exec] .buildresults-data-failed { color: #F30; }
     [exec]
     [exec] .stylesection { margin-left: 4px; }
     [exec] .header-title { font-size:12px; color:#000; font-weight:bold; padding-bottom:10pt; }
     [exec] .header-label { font-weight:bold; }
     [exec] .header-data { color:#000; }
     [exec] .header-data-error { color:#000; white-space:pre; }
     [exec]
     [exec] .section-table { margin-top:10px; }
     [exec] .sectionheader { background-color:#006; color:#FFF; }
     [exec] .section-data { font-size:9px; color:#000; }
     [exec] .section-oddrow { background-color:#F0F7FF; }
     [exec] .section-evenrow { background-color:#FFF; }
     [exec] .section-error { font-size:9px; color:#F30; white-space:pre; }
     [exec]
     [exec] .warning { color: darkorange; }
     [exec] .error { color:red }
     [exec] .pluginLinks { float:right; margin-top:10px; padding:10px; background-color:#000066; color:White }</style></head><body>CruiseControl.NET Build Results for project Project#9 (<a href="">web page</a>)<p></p><hr size="1" width="98%" align="left" color="#888888"/></body></html>
     [exec]   Expected: True
     [exec]   But was:  False
     [exec]   at ThoughtWorks.CruiseControl.UnitTests.Core.Publishers.EmailPublisherTest.EmailMessageWithDetails () [0x00000] in <dac301ed37f1469e88502226d4a9082d>:0
     [exec]
     [exec] 3) Failed : ThoughtWorks.CruiseControl.UnitTests.Core.Publishers.EmailPublisherTest.UnitTestResultsShouldBeIncludedInEmailMessageWhenIncludesDetailsIsTrue
     [exec]   message does not contain 'Tests run': <html><head><style>body, table, form, input, td, th, p, textarea, select
     [exec] {
     [exec]  font-family: verdana, helvetica, arial;
     [exec]  font-size: 11px;
     [exec] }
     [exec]
     [exec] a:hover { color:#FC0; }
     [exec]
     [exec] .main-panel { color:#FC0; }
     [exec]
     [exec] .link { color:#FFF; text-decoration:none; }
     [exec] .link-failed { color:#F30; text-decoration:none; }
     [exec] .buildresults-header { color: #FFF; font-weight: bold; }
     [exec] .buildresults-data { color: #9F3; }
     [exec] .buildresults-data-failed { color: #F30; }
     [exec]
     [exec] .stylesection { margin-left: 4px; }
     [exec] .header-title { font-size:12px; color:#000; font-weight:bold; padding-bottom:10pt; }
     [exec] .header-label { font-weight:bold; }
     [exec] .header-data { color:#000; }
     [exec] .header-data-error { color:#000; white-space:pre; }
     [exec]
     [exec] .section-table { margin-top:10px; }
     [exec] .sectionheader { background-color:#006; color:#FFF; }
     [exec] .section-data { font-size:9px; color:#000; }
     [exec] .section-oddrow { background-color:#F0F7FF; }
     [exec] .section-evenrow { background-color:#FFF; }
     [exec] .section-error { font-size:9px; color:#F30; white-space:pre; }
     [exec]
     [exec] .warning { color: darkorange; }
     [exec] .error { color:red }
     [exec] .pluginLinks { float:right; margin-top:10px; padding:10px; background-color:#000066; color:White }</style></head><body>CruiseControl.NET Build Results for project test (<a href="">web page</a>)<p></p><hr size="1" width="98%" align="left" color="#888888"/></body></html>
     [exec]   Expected: True
     [exec]   But was:  False
     [exec]   at ThoughtWorks.CruiseControl.UnitTests.Core.Publishers.EmailPublisherTest.UnitTestResultsShouldBeIncludedInEmailMessageWhenIncludesDetailsIsTrue () [0x00000] in <dac301ed37f1469e88502226d4a9082d>:0
     [exec]
     [exec] 4) Failed : ThoughtWorks.CruiseControl.UnitTests.Core.Publishers.EmailPublisherTest.VerifyEmailSubjectAndMessageForExceptionIntegrationResult
     [exec]   message does not contain exception result message: <html><head><style>body, table, form, input, td, th, p, textarea, select
     [exec] {
     [exec]  font-family: verdana, helvetica, arial;
     [exec]  font-size: 11px;
     [exec] }
     [exec]
     [exec] a:hover { color:#FC0; }
     [exec]
     [exec] .main-panel { color:#FC0; }
     [exec]
     [exec] .link { color:#FFF; text-decoration:none; }
     [exec] .link-failed { color:#F30; text-decoration:none; }
     [exec] .buildresults-header { color: #FFF; font-weight: bold; }
     [exec] .buildresults-data { color: #9F3; }
     [exec] .buildresults-data-failed { color: #F30; }
     [exec]
     [exec] .stylesection { margin-left: 4px; }
     [exec] .header-title { font-size:12px; color:#000; font-weight:bold; padding-bottom:10pt; }
     [exec] .header-label { font-weight:bold; }
     [exec] .header-data { color:#000; }
     [exec] .header-data-error { color:#000; white-space:pre; }
     [exec]
     [exec] .section-table { margin-top:10px; }
     [exec] .sectionheader { background-color:#006; color:#FFF; }
     [exec] .section-data { font-size:9px; color:#000; }
     [exec] .section-oddrow { background-color:#F0F7FF; }
     [exec] .section-evenrow { background-color:#FFF; }
     [exec] .section-error { font-size:9px; color:#F30; white-space:pre; }
     [exec]
     [exec] .warning { color: darkorange; }
     [exec] .error { color:red }
     [exec] .pluginLinks { float:right; margin-top:10px; padding:10px; background-color:#000066; color:White }</style></head><body>CruiseControl.NET Build Results for project Project#9 (<a href="">web page</a>)<p></p><hr size="1" width="98%" align="left" color="#888888"/></body></html>
     [exec]   Expected: True
     [exec]   But was:  False
     [exec]   at ThoughtWorks.CruiseControl.UnitTests.Core.Publishers.EmailPublisherTest.VerifyEmailSubjectAndMessageForExceptionIntegrationResult () [0x00000] in <dac301ed37f1469e88502226d4a9082d>:0
     [exec]
     [exec] 5) Failed : ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol.PvcsHistoryParserTest.ParseModifications
     [exec]   Arrays should have same length
     [exec]   Expected: 4
     [exec]   But was:  0
     [exec]   at ThoughtWorks.CruiseControl.UnitTests.CustomAssertion.AssertEqualArrays (System.Array expected, System.Array actual) [0x00000] in <dac301ed37f1469e88502226d4a9082d>:0
     [exec]   at ThoughtWorks.CruiseControl.UnitTests.Core.Sourcecontrol.PvcsHistoryParserTest.ParseModifications () [0x00000] in <dac301ed37f1469e88502226d4a9082d>:0
     [exec]
     [exec] 6) Failed : ThoughtWorks.CruiseControl.UnitTests.Core.Util.LogFileTraceListenerTest.LoggingAnEntryShouldFlushLogFileIfAutoFlushIsEnabled
     [exec]   Search substring: doh! is not contained in target:
     [exec]   Expected: True
     [exec]   But was:  False
     [exec]   at ThoughtWorks.CruiseControl.UnitTests.CustomAssertion.AssertContains (System.String search, System.String target) [0x00000] in <dac301ed37f1469e88502226d4a9082d>:0
     [exec]   at ThoughtWorks.CruiseControl.UnitTests.Core.Util.LogFileTraceListenerTest.LoggingAnEntryShouldFlushLogFileIfAutoFlushIsEnabled () [0x00000] in <dac301ed37f1469e88502226d4a9082d>:0
     [exec]
     [exec] 7) Failed : ThoughtWorks.CruiseControl.UnitTests.Core.Util.RegistryTest.GetLocalMachineSubKeyValue
     [exec]   #A1
     [exec]   Expected: not null
     [exec]   But was:  null
     [exec]   at ThoughtWorks.CruiseControl.UnitTests.Core.Util.RegistryTest.GetLocalMachineSubKeyValue () [0x00000] in <dac301ed37f1469e88502226d4a9082d>:0
     [exec]
     [exec] 8) Failed : ThoughtWorks.CruiseControl.UnitTests.Core.Util.WildCardPathTest.StringWithWildcardsInPathShouldUseFolderWildcardsAndSimpleWildcardForAFolderName
     [exec]   Expected: 3
     [exec]   But was:  9
     [exec]   at ThoughtWorks.CruiseControl.UnitTests.Core.Util.WildCardPathTest.StringWithWildcardsInPathShouldUseFolderWildcardsAndSimpleWildcardForAFolderName () [0x00000] in <dac301ed37f1469e88502226d4a9082d>:0
     [exec]
     [exec] 9) Failed : ThoughtWorks.CruiseControl.UnitTests.Core.Util.WildCardPathTest.StringWithWildcardsInPathShouldUseWildcardsFollowedByFolderNameSegment
     [exec]   Expected: 3
     [exec]   But was:  9
     [exec]   at ThoughtWorks.CruiseControl.UnitTests.Core.Util.WildCardPathTest.StringWithWildcardsInPathShouldUseWildcardsFollowedByFolderNameSegment () [0x00000] in <dac301ed37f1469e88502226d4a9082d>:0
     [exec]
     [exec] 10) Failed : ThoughtWorks.CruiseControl.UnitTests.Core.Util.WildCardPathTest.StringWithWildcardsInPathShouldUseWildcardsInTwoFolderSegments
     [exec]   Expected: 5
     [exec]   But was:  9
     [exec]   at ThoughtWorks.CruiseControl.UnitTests.Core.Util.WildCardPathTest.StringWithWildcardsInPathShouldUseWildcardsInTwoFolderSegments () [0x00000] in <dac301ed37f1469e88502226d4a9082d>:0
     [exec]
     [exec] 11) Failed : ThoughtWorks.CruiseControl.UnitTests.Core.Util.XslTransformerTest.ShouldFailWhenXslInvalid
     [exec]   Expected: <ThoughtWorks.CruiseControl.Core.CruiseControlException>
     [exec]   But was:  <System.ArgumentNullException: Value cannot be null.
     [exec] Parameter name: args
     [exec]   at System.String.Format (System.IFormatProvider provider, System.String format, System.Object[] args) [0x00003] in <671ef0784b04474c83bb500a849492f2>:0
     [exec]   at SR.GetString (System.Globalization.CultureInfo culture, System.String name, System.Object[] args) [0x00000] in <1df69a54e6a44b9498dc8e01aafc8e4a>:0
     [exec]   at SR.GetString (System.String name, System.Object[] args) [0x00005] in <1df69a54e6a44b9498dc8e01aafc8e4a>:0
     [exec]   at System.Xml.Utils.Res.GetString (System.String name, System.Object[] args) [0x00000] in <1df69a54e6a44b9498dc8e01aafc8e4a>:0
     [exec]   at System.Xml.Xsl.XslTransformException.CreateMessage (System.String res, System.String[] args) [0x00002] in <1df69a54e6a44b9498dc8e01aafc8e4a>:0
     [exec]   at System.Xml.Xsl.XslTransformException..ctor (System.Exception inner, System.String res, System.String[] args) [0x00000] in <1df69a54e6a44b9498dc8e01aafc8e4a>:0
     [exec]   at System.Xml.Xsl.XslLoadException..ctor (System.Exception inner, System.Xml.Xsl.ISourceLineInfo lineInfo) [0x00000] in <1df69a54e6a44b9498dc8e01aafc8e4a>:0
     [exec]   at System.Xml.Xsl.Xslt.XsltLoader.LoadStylesheet (System.Xml.XmlReader reader, System.Boolean include) [0x00131] in <1df69a54e6a44b9498dc8e01aafc8e4a>:0
     [exec]   at System.Xml.Xsl.Xslt.XsltLoader.Load (System.Xml.XmlReader reader) [0x00017] in <1df69a54e6a44b9498dc8e01aafc8e4a>:0
     [exec]   at System.Xml.Xsl.Xslt.XsltLoader.Load (System.Xml.Xsl.Xslt.Compiler compiler, System.Object stylesheet, System.Xml.XmlResolver xmlResolver) [0x00099] in <1df69a54e6a44b9498dc8e01aafc8e4a>:0
     [exec]   at System.Xml.Xsl.Xslt.Compiler.Compile (System.Object stylesheet, System.Xml.XmlResolver xmlResolver, System.Xml.Xsl.Qil.QilExpression& qil) [0x00005] in <1df69a54e6a44b9498dc8e01aafc8e4a>:0
     [exec]   at System.Xml.Xsl.XslCompiledTransform.CompileXsltToQil (System.Object stylesheet, System.Xml.Xsl.XsltSettings settings, System.Xml.XmlResolver stylesheetResolver) [0x0000e] in <1df69a54e6a44b9498dc8e01aafc8e4a>:0
     [exec]   at System.Xml.Xsl.XslCompiledTransform.LoadInternal (System.Object stylesheet, System.Xml.Xsl.XsltSettings settings, System.Xml.XmlResolver stylesheetResolver) [0x00018] in <1df69a54e6a44b9498dc8e01aafc8e4a>:0
     [exec]   at System.Xml.Xsl.XslCompiledTransform.Load (System.String stylesheetUri, System.Xml.Xsl.XsltSettings settings, System.Xml.XmlResolver stylesheetResolver) [0x00014] in <1df69a54e6a44b9498dc8e01aafc8e4a>:0
     [exec]   at ThoughtWorks.CruiseControl.Core.Util.XslTransformer.LoadStylesheet (System.Xml.Xsl.XslCompiledTransform transform, System.String xslFileName) [0x00010] in <d036085c2a5b4ee994fedc4c3b2455ac>:0
     [exec]   at ThoughtWorks.CruiseControl.Core.Util.XslTransformer.NewXslTransform (System.String transformerFileName) [0x00012] in <d036085c2a5b4ee994fedc4c3b2455ac>:0
     [exec]   at ThoughtWorks.CruiseControl.Core.Util.XslTransformer.Transform (System.String input, System.String xslFilename, System.Collections.Hashtable xsltArgs) [0x00000] in <d036085c2a5b4ee994fedc4c3b2455ac>:0
     [exec]   at ThoughtWorks.CruiseControl.UnitTests.Core.Util.XslTransformerTest+<>c__DisplayClass7_0.<ShouldFailWhenXslInvalid>b__0 () [0x00005] in <dac301ed37f1469e88502226d4a9082d>:0
     [exec]   at (wrapper managed-to-native) System.Reflection.RuntimeMethodInfo.InternalInvoke(System.Reflection.RuntimeMethodInfo,object,object[],System.Exception&)
     [exec]   at System.Reflection.RuntimeMethodInfo.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x0006a] in <671ef0784b04474c83bb500a849492f2>:0
     [exec] --- End of stack trace from previous location where exception was thrown ---
     [exec]
     [exec]   at NUnit.Framework.Internal.ExceptionHelper.Rethrow (System.Exception exception) [0x00006] in <be0e2b70ca254bb684417cccea7d5290>:0
     [exec]   at NUnit.Framework.Internal.Reflect.DynamicInvokeWithTransparentExceptions (System.Delegate delegate) [0x00014] in <be0e2b70ca254bb684417cccea7d5290>:0
     [exec]   at NUnit.Framework.Internal.ExceptionHelper.RecordException (System.Delegate parameterlessDelegate, System.String parameterName) [0x00067] in <be0e2b70ca254bb684417cccea7d5290>:0 >
     [exec]   at ThoughtWorks.CruiseControl.UnitTests.Core.Util.XslTransformerTest.ShouldFailWhenXslInvalid () [0x00000] in <dac301ed37f1469e88502226d4a9082d>:0
     [exec]
     [exec] 12) Failed : ThoughtWorks.CruiseControl.UnitTests.IntegrationTests.PublisherTests.PackagePublisherPackageFolderMustRespectHierarchy
     [exec]   Expected string length 42 but was 0. Strings differ at index 0.
     [exec]   Expected: "MegaWebSite/AFolder/b.txtMegaWebSite/a.txt"
     [exec]   But was:  <string.Empty>
     [exec]   -----------^
     [exec]   at ThoughtWorks.CruiseControl.UnitTests.IntegrationTests.PublisherTests.PackagePublisherPackageFolderMustRespectHierarchy () [0x00000] in <dac301ed37f1469e88502226d4a9082d>:0
     [exec]
     [exec] 13) Failed : ThoughtWorks.CruiseControl.UnitTests.IntegrationTests.PublisherTests.PackagePublisherWithFlattenFiles
     [exec]   Expected string length 10 but was 0. Strings differ at index 0.
     [exec]   Expected: "a.txtb.txt"
     [exec]   But was:  <string.Empty>
     [exec]   -----------^
     [exec]   at ThoughtWorks.CruiseControl.UnitTests.IntegrationTests.PublisherTests.PackagePublisherWithFlattenFiles () [0x00000] in <dac301ed37f1469e88502226d4a9082d>:0
     [exec]
     [exec] 14) Failed : ThoughtWorks.CruiseControl.UnitTests.IntegrationTests.PublisherTests.PackagePublisherWithoutFlattenFiles
     [exec]   Expected string length 30 but was 0. Strings differ at index 0.
     [exec]   Expected: "Info/Sub1/a.txtInfo/Sub1/b.txt"
     [exec]   But was:  <string.Empty>
     [exec]   -----------^
     [exec]   at ThoughtWorks.CruiseControl.UnitTests.IntegrationTests.PublisherTests.PackagePublisherWithoutFlattenFiles () [0x00000] in <dac301ed37f1469e88502226d4a9082d>:0

Any hints/pointers are most welcome, I'll keep updating this branch with new fixes