### PR TITLE
Section handlers deprecated implementation

### DIFF
--- a/project/UnitTests/Core/Config/XslFilesSectionHandlerTest.cs
+++ b/project/UnitTests/Core/Config/XslFilesSectionHandlerTest.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Configuration;
 using NUnit.Framework;
+using ThoughtWorks.CruiseControl.Core.Config;
 
 namespace ThoughtWorks.CruiseControl.UnitTests.Core.Config
 {
@@ -10,8 +11,10 @@ namespace ThoughtWorks.CruiseControl.UnitTests.Core.Config
         [Test]
         public void GetConfig()
         {
-            IList list = (IList) ConfigurationManager.GetSection("xslFiles");
-            Assert.IsNotNull(list);
+            var section = ConfigurationManager.GetSection("xslFiles") as XslFilesSectionHandler;
+            Assert.IsNotNull(section, "section should not be null");
+            IList list = section.FileNames;
+            Assert.IsNotNull(list, "file names list should not be null");
             Assert.AreEqual(5, list.Count);
             Assert.AreEqual(@"xsl\header.xsl", list[0]);
             Assert.AreEqual(@"xsl\compile.xsl", list[1]);

--- a/project/UnitTests/Core/Config/XslFilesSectionHandlerTest.cs
+++ b/project/UnitTests/Core/Config/XslFilesSectionHandlerTest.cs
@@ -5,7 +5,7 @@ using NUnit.Framework;
 namespace ThoughtWorks.CruiseControl.UnitTests.Core.Config
 {
     [TestFixture]
-    public class XslFilesSectionHandler : CustomAssertion
+    public class XslFilesSectionHandlerTest : CustomAssertion
     {
         [Test]
         public void GetConfig()

--- a/project/core/Config/XslFilesSectionHandler.cs
+++ b/project/core/Config/XslFilesSectionHandler.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Configuration;
 using System.Xml;
 
@@ -7,29 +9,78 @@ namespace ThoughtWorks.CruiseControl.Core.Config
     /// <summary>
     /// 	
     /// </summary>
-	public class XslFilesSectionHandler : IConfigurationSectionHandler
+	public class XslFilesSectionHandler : ConfigurationSection
 	{
-        /// <summary>
-        /// Creates the specified parent.	
-        /// </summary>
-        /// <param name="parent">The parent.</param>
-        /// <param name="configContext">The config context.</param>
-        /// <param name="section">The section.</param>
-        /// <returns></returns>
-        /// <remarks></remarks>
-		public object Create(object parent, object configContext, XmlNode section)
-		{
-			ArrayList files = new ArrayList();
-
-			foreach (XmlNode node in section.ChildNodes) 
-			{
-				if (node.NodeType == System.Xml.XmlNodeType.Element) 
-				{
-					files.Add(node.Attributes["name"].Value);
-				}
-			}
-
-			return files;
-		}
+        [ConfigurationProperty("", IsDefaultCollection = true)]
+        [ConfigurationCollection(typeof(XslFilesCollection), AddItemName = "file")]
+        public XslFilesCollection XslFiles
+        {
+            get
+            {
+                return  (XslFilesCollection)base[""];
+            }
+        }
+        
+        public List<string> FileNames 
+        {
+            get
+            {
+                var result = new List<string>();
+    			foreach (var file in XslFiles) 
+            		result.Add(((XslFileElement)file).Name);
+                    
+                return result;
+            }
+        }
 	}
+
+    public class XslFilesCollection : ConfigurationElementCollection
+    {
+        protected override ConfigurationElement CreateNewElement()
+        {
+            return new XslFileElement();
+        }
+    
+        protected override Object GetElementKey(ConfigurationElement element)
+        {
+            return ((XslFileElement)element).Name;
+        }
+    
+        public XslFileElement this[int index]
+        {
+            get
+            {
+                return (XslFileElement)BaseGet(index);
+            }
+            set
+            {
+                if (BaseGet(index) != null)
+                    BaseRemoveAt(index);
+
+                BaseAdd(index, value);
+            }
+        }
+
+        protected override void BaseAdd(ConfigurationElement element)
+        {
+            BaseAdd(element, false);
+        }
+    }
+    
+    public class XslFileElement : ConfigurationElement
+    {
+        [ConfigurationProperty("name", IsRequired = true, IsKey = true)]
+        public string Name
+        {
+            get
+            {
+                return (string)this["name"];
+            }
+            set
+            {
+                this["name"] = value;
+            }
+        }
+    }
 }
+

--- a/project/core/publishers/BuildLogTransformer.cs
+++ b/project/core/publishers/BuildLogTransformer.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using System.Configuration;
 using System.Text;
 using System.Xml.XPath;
+using ThoughtWorks.CruiseControl.Core.Config;
 using ThoughtWorks.CruiseControl.Core.Util;
 
 namespace ThoughtWorks.CruiseControl.Core.Publishers
@@ -20,8 +21,8 @@ namespace ThoughtWorks.CruiseControl.Core.Publishers
 		/// <returns></returns>
 		public string TransformResultsWithAllStyleSheets(XPathDocument document)
 		{
-			IList list = (IList) ConfigurationManager.GetSection("xslFiles");
-			return TransformResults(list, document);
+			var section = ConfigurationManager.GetSection("xslFiles") as XslFilesSectionHandler;
+			return TransformResults(section?.FileNames, document);
 		}
 
         /// <summary>

--- a/project/core/publishers/BuildLogTransformer.cs
+++ b/project/core/publishers/BuildLogTransformer.cs
@@ -22,6 +22,9 @@ namespace ThoughtWorks.CruiseControl.Core.Publishers
 		public string TransformResultsWithAllStyleSheets(XPathDocument document)
 		{
 			var section = ConfigurationManager.GetSection("xslFiles") as XslFilesSectionHandler;
+            if (section == null)
+                section = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None).GetSection("xslFiles") as XslFilesSectionHandler;
+            
 			return TransformResults(section?.FileNames, document);
 		}
 


### PR DESCRIPTION
While working on Linux unit tests (#304), I came across the way the `xslFiles` section is accessed.
The current code is using `ConfigurationManager.GetSection("xslFiles")` and casts it directly to an `IList` instance. Unfortunately, for a reason that I could not identify, this always returns `null` under Linux/Mono.
However, using `ConfigurationManager.OpenExeConfiguration` gives me a valid `filePath` along with a non null value for the `GetSection` code.
Unfortunately, the returned object is a `DefaultSection` instance that does not cast to `IList` at all.

This led me to review the code that "reads" this from the `.config` file and I discovered that it is implemented via the `XslFilesSectionHandler` class. It does so by implementing the `IConfigurationSectionHandler` interface which has been deprecated for a long time now.
Changing the code to follow today's standards allows to get an instance of `XslFilesSectionHandler` returned by `GetSection` and as such access any code on it that could return a list of strings as expected by users of this section.

This pull request implements the required changes and with those, I have solved failed tests 2, 3 and 4.

Note that there is another location where `GetSection` is called, inside `CruiseServerFactory.CreateLocal`, along with the `ServerConfigurationHandler` section handler that implements `IConfigurationSectionHandler`. I believe the same set of changes is required there as well.

There is one last usage of `IConfigurationSectionHandler`, and it's in `CruiseControlConfigSectionHandler`. But I don't understand its usage as its `Create` method returns `null` in all cases. Maybe it should just be removed.